### PR TITLE
docs: 社名の表記を PROPAGANDIST CORPORATION に統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ jOOQ はデュアルライセンスで、オープンソース DB では Apache 
 
 Apache License 2.0 — [LICENSE](LICENSE) を参照してください。
 
-Copyright PROPAGANDIST株式会社
+Copyright PROPAGANDIST CORPORATION
 
 SendGrid および Twilio は Twilio Inc. の商標です。本プロジェクトは
 Twilio Inc. とは無関係であり、公式に承認されたものではありません。
@@ -173,4 +173,4 @@ Twilio Inc. とは無関係であり、公式に承認されたものではあ�
 
 ## 作っているところ
 
-[PROPAGANDIST株式会社](https://propagandist.co.jp) — 横浜のシステム開発会社です。
+[PROPAGANDIST CORPORATION](https://propagandist.co.jp) — 横浜のシステム開発会社です。

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -11,7 +11,7 @@
 |---|---|---|
 | 形態 | リファレンス実装 | ライブラリ化・Starter 化はしない |
 | 公開目的 | PROPAGANDIST のブランディング | 利用拡大は非ゴール |
-| ライセンス | Apache License 2.0 | 著作権者は PROPAGANDIST株式会社 |
+| ライセンス | Apache License 2.0 | 著作権者は PROPAGANDIST CORPORATION |
 | DB | PostgreSQL のみ | 他 DB 対応は非ゴール |
 | 公開先 | <https://github.com/propagandist/recibir> | public。Apache-2.0。個人アカウントは不可 |
 | 記事 | Zenn に投稿 | 記事が主、リポジトリが裏付け |


### PR DESCRIPTION
## 発端

2026-08-26 実測で、リポジトリ内の社名表記が割れていた。`README.md` の著作権表示と
「作っているところ」、`docs/HANDOVER.md` の決定事項テーブルが `PROPAGANDIST株式会社`
（半角ラテン + 株式会社）。同テーブルの隣の行だけが単独の `PROPAGANDIST`。

## 現状の問題

recibir は public リポジトリで、README がそのまま公開物になる。著作権表示は Apache-2.0 の
帰属先を示すものなので、表記が揺れていると帰属先が読み取りにくい。

揺れは org 側のほうが広い。org 正本 `docs/legal-baseline.md` §3.6 が「★ 社名の表記を org で
そろえる」を**未決事項**として持ち、2026-08-22 実測で cartera が全角、corporate-web-site が
半角と記録している。

## 目指す状態

社名は **`PROPAGANDIST CORPORATION`** で統一する。**この決定は org 全体のものとして扱う。**

## 判断とその理由

**値の正本は org 側に置き、`CLAUDE.md`「文章の値」には書かない。** org 全体の決定である以上、
recibir に値を書けばその日から正本が 2 つになる（判断規律は org `work-conventions.md` §0 と
`writing-baseline.md` §0）。正本は `legal-baseline.md` §3.6。

**`| 公開目的 | PROPAGANDIST のブランディング |` は変更しない。** ブランド名としての単独使用で
あって、商号表記とは別。結果として `docs/HANDOVER.md` の 13 行目と 14 行目で 2 通りが並ぶが、
これは意図した状態。

**識別子は対象外。** パッケージ名 `app.propagandist.*`、GitHub org 名、ドメイン
`propagandist.co.jp`。`propagandist` の総出現行数が変更前後とも 18 行で一致することを、
置換が識別子に及んでいないことの検証に使った。

**和欧間スペース検査に出ても直さない。** org `writing-baseline.md` §8 が商号を
「直してはいけないもの」として名指ししている。

## 受け入れ基準

**機械で確かめられるもの**（いずれも実行済み・通過）:

- `rg -n 'PROPAGANDIST株式会社|ＰＲＯＰＡＧＡＮＤＩＳＴ|プロパガンディスト' . --hidden -g '!.git'` → 0 件
- `rg -n 'PROPAGANDIST CORPORATION' . --hidden -g '!.git'` → 3 件
- `rg -ni 'propagandist' . --hidden -g '!.git'` → 18 行（変更前と同数。減っていたら識別子を壊している）
- `rg -n 'PROPAGANDIST のブランディング' docs/HANDOVER.md` → 1 件

**目視でしか確かめられないもの**:

- README「## ライセンス」節が Apache-2.0 の帰属先として読めること
- 「## 作っているところ」のリンクが生きていること

## 対象範囲

- `README.md` — 2 箇所（167 行目の `Copyright`、176 行目のリンクテキスト）
- `docs/HANDOVER.md` — 1 箇所（14 行目、決定事項テーブルの著作権者）

## 却下した案とその理由

**`CLAUDE.md`「文章の値」に社名表記の行を足す。** 次に触る人が戻すのを防げる。だが org 全体の
決定を recibir 側に書くと値の正本が 2 つになる。防ぎたい事故より、正本が割れる害のほうが大きい。

**`LICENSE` の付録 `Copyright [yyyy] [name of copyright owner]` を埋める。** 未記入を埋めるのは
「統一」ではなく「追加」。`docs/HANDOVER.md` の未決事項（ライセンスヘッダを全ファイルに入れるか
`NOTICE` に集約するか）と一緒に決めるほうが筋が通る。

**`| 公開目的 | PROPAGANDIST のブランディング |` も揃える。** 上記のとおりブランド名であり、
商号表記の統一とは軸が違う。

## 残る宿題（このリポジトリ外）

org 全体の決定として扱う以上、recibir を直しただけでは完了しない。

- **org `docs/legal-baseline.md` §3.6 に決定を書く。** 今回の英文表記は同節が記録する全角・半角の
  **どちらでもない第三の形**なので、書くまでは org 内が 3 通りに増えた状態で残る
- **追随が必要**: cartera / corporate-web-site / Kerberos の Typst 帳票テンプレート 6 ファイル
  （見積書・注文書という**対外帳票**が全角）
- org `writing-baseline.md` §8 が半角形を「和欧間スペース検査に出るが直してはいけないもの」の
  実例として引用しており、その記述が古くなる
- **商号の正しさは文書では決まらない**（§3.6 の明言）。定款・登記上の英文表記との一致は、
  文書ではなく登記の事実で確かめること
