### PR TITLE
docs: README の設計図を Mermaid にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,12 @@ recibir はこの四つに対する一つの答えです。
 
 ## 設計
 
-```
-SendGrid ──POST──> 受信エンドポイント
-                        │ ① 署名検証
-                        │ ② 生イベントを INSERT
-                        │ ③ 200 を返す
-                        ▼
-                   sendgrid_event（append-only）
-                        │ 非同期ワーカー
-                        ▼
-              email_address_state（導出状態）
-                        ▲
-                        │ 日次バッチ
-                   Suppression API
+```mermaid
+flowchart TD
+    SG[SendGrid] -->|POST| EP["受信エンドポイント<br>① 署名検証<br>② 生イベントを INSERT<br>③ 200 を返す"]
+    EP --> EV[("sendgrid_event<br>append-only")]
+    EV -->|非同期ワーカー| ST[("email_address_state<br>導出状態")]
+    API[Suppression API] -->|日次バッチ| ST
 ```
 
 ### 受信と解釈を分ける


### PR DESCRIPTION
Closes #6

## なぜ

図の書き方がリポジトリ内で割れていた。`docs/er.md` は Mermaid（#3 / PR #4）で、
README だけが罫線素材の ASCII 図だった。

README が読まれるのは GitHub public と Zenn 記事（`docs/HANDOVER.md`）で、どちらも
Mermaid を描画する。ASCII のままでは等幅フォント前提のテキストが出るだけになり、
線やノードを足すたびに周囲の空白を手で数え直すことになる。ずれても検査に掛からない。

**読み取れる内容は現行と変えていない。** ノードが 5 つ、線が 4 本、受信エンドポイントに ①②③。

## 判断

### ①②③ をノード内に置き、線に分解しない

分解すると線が 1 本増える。レスポンスの分岐（200 / 403 / 500）の正本は
`docs/SPEC.md` 4.2 の表であって、README の図が担う役ではない。

### テーブルは円柱 `[(...)]`、外部システムと処理は角丸 `[...]`

正本のテーブルと外部の境界が、形で読める。

### Suppression API の矢印の向きは、元図と同じにならない

`flowchart TD` のレイアウトは自動で、元の ASCII は下から上へ `▲` で指していた。
意味（Suppression API → `email_address_state`）は保たれるので、この差は受け入れた。

**却下した案は #6 に書いた。** ここには写さない。

## 確かめたこと

手元で実走した（2026-08-26）。

```
$ grep -rn '^```mermaid' README.md docs/*.md
README.md:38:```mermaid
docs/er.md:10:```mermaid

$ LC_ALL=C.UTF-8 grep -nP '[│├└─┌┐┘▼▲]' README.md
（0 件。終了コード 1）
```

2 本目にロケール指定が要ることは `writing-baseline.md` §8 の★★ のとおりで、
付けないと落ちたまま 0 件に見える。**終了コードが 1 であることまで見た**（落ちたなら 2）。

**残るのは目視。Files changed で図が描画されているかを見てほしい。**
ローカルの Markdown プレビューは拡張に依るので、手元では確かめられない。
