### PR TITLE
docs: パッケージのルートを io.propagandist にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ build/
 .kotlin/
 
 ### jOOQ 生成コード ###
-# app.propagandist.jooq.* は generateJooq が作る。src にはコミットしない（CLAUDE.md 参照）
+# io.propagandist.jooq.* は generateJooq が作る。src にはコミットしない（CLAUDE.md 参照）
 src/generated/
 
 ### ログ ###

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ docker compose up -d              # PostgreSQL 起動
 ./gradlew bootRun
 ```
 
-**`generateJooq` が通っていないと、`app.propagandist.jooq.*` が存在せず
+**`generateJooq` が通っていないと、`io.propagandist.jooq.*` が存在せず
 永続化層は一切コンパイルできません。** 順序を守ってください。
 
 テストは SendGrid アカウントなしで通ること。CI もこの前提です。
@@ -84,14 +84,14 @@ docker compose up -d              # PostgreSQL 起動
 ## パッケージ構成
 
 ```
-app.propagandist.recibir
+io.propagandist.recibir
 ├── webhook/      受信・署名検証・生イベント投入
 ├── event/        イベント解釈・導出状態の再構築
 ├── reconcile/    Suppression API との突き合わせ
 └── config/       Security、スケジューラ
 ```
 
-生成コードは `app.propagandist.jooq` 以下（`src` にはコミットしない）。
+生成コードは `io.propagandist.jooq` 以下（`src` にはコミットしない）。
 
 ## コーディング規約
 

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -30,7 +30,7 @@
 - `build.gradle.kts` — codegen 設定を含む雛形
 
 パッケージは `app.propagandist.sendgrid.webhook` で書かれている。
-`app.propagandist.recibir.*` に置き換えること。
+`io.propagandist.recibir.*` に置き換えること。
 
 ## 作業順序
 
@@ -48,7 +48,7 @@
 4. **jOOQ codegen** — `generateJooq` を実行
    :::warning
    **3 が完了して DB にスキーマが存在しないと、コード生成は空になります。**
-   ここを飛ばして 5 以降に進むと `app.propagandist.jooq.*` が解決できず、
+   ここを飛ばして 5 以降に進むと `io.propagandist.jooq.*` が解決できず、
    永続化層が一切コンパイルできません。原因が分かりにくいので必ず先に通すこと。
    :::
 


### PR DESCRIPTION
#11 の実行。`app.propagandist` → `io.propagandist` を 6 箇所。

## なぜ `app.` を捨てるか

**`app.` は当社が保有していない TLD に基づいている。** 逆ドメイン慣習は、パッケージのルートを
保有ドメインの逆順に取る。`propagandist.app` を当社は持っていないので、現在の名前はその慣習から
外れた形だった。`propagandist.io` は保有しているので、これは**慣習外の名前を慣習内へ戻す変更**になる。

これが効くのは、このリポジトリが**読まれることを目的にしている**ためである
（`CLAUDE.md`「最重要」）。設計を読みに来た人が命名で引っかかると、
読ませたいものの手前で止まってしまう。

## なぜ今か

**実装が始まれば、パッケージ名は `src` のディレクトリ構造と `build.gradle.kts` の codegen 設定に
埋まる。** 積んだ履歴が「実績」として先に決めてしまう（org `work-conventions.md` §6 末尾）。
いまは文字列 6 箇所で済む。

**構成は変えていない。** `recibir` と `jooq` が兄弟である関係も、その下の 4 パッケージも動かしていない。

## 据え置いた 1 箇所

`docs/HANDOVER.md`「下書きのある成果物」の草案側の記述（`app.propagandist.sendgrid.webhook`）は
触っていない。**リポジトリ外の草案が実際にどう書かれているかという観測**であって、当方の決定では
ないためである。書き換えると、草案を開いた人が存在しない文字列を探すことになる。
草案の現状と置き換え先の対比が、この節の意味そのものである。

## 却下した案

- **`io.propagandist` 直下に置く**（`recibir` セグメントを外す）— org 名がプロダクト名を兼ねてしまい、
  当社の他プロジェクトと同じルートに同居できなくなる。recibir を読んだ人がこの名前を自分の
  コードベースへ持っていくときにも衝突しやすい
- **`jp.co.propagandist.recibir`** — `propagandist.co.jp` の逆順として正しい形ではあるが、
  `propagandist.io` を保有している以上、より短い `io.propagandist` を選べない理由がない
- **草案側の記述も併せて書き換える** — 上の「据え置いた 1 箇所」

## 検査

**受け入れ基準（機械で確かめられるもの）**——2026-08-27 実走。

- `git grep -n 'app\.propagandist'` → **1 件**（草案側の記述のみ）
- `git grep -n 'io\.propagandist'` → **6 件**

**校正**——org `writing-baseline.md` §8 の 5 本を**置換の前後で実走し、出力が完全に一致した**
（2026-08-27、対象は `docs/*.md` ＋ `README.md` ＋ `CLAUDE.md` の **5 ファイル**）。

| 検査 | 前 | 後 |
|---|---|---|
| 和欧間スペースの欠落 | 0 件（**終了コード 1**。落ちたなら 2） | 同 |
| 敬体と常体の混在 | 3 ファイル | 同 |
| 冗長表現 | 1 件 | 同 |
| 同一文末の 3 連続以上 | 2 箇所 | 同 |
| 一文の長さ | n=297 median=32 p90=49 max=88 over60=7 | 同 |

置換した 6 箇所はすべてインラインコードかコードブロックの中にあり、どの検査にも掛からない。
**見込みで書かず、前後で打って一致を確かめた。**

**ビルドでは確かめられない。** 実装が未着手のため、この命名がコンパイルを通るのは
`docs/HANDOVER.md` の作業順序 1（プロジェクト初期化）の日である。

**残るのは目視。** `docs/HANDOVER.md` の 2 行が「草案は `app.propagandist.sendgrid.webhook` で
書かれている ／ `io.propagandist.recibir.*` に置き換えること」という対比として読めるか、
`CLAUDE.md` の構成ツリーが `io.propagandist.recibir` の下に 4 パッケージを持つ形で崩れていないかを、
Files changed で見てほしい。

## 含めていないもの

**`docs/HANDOVER.md`「未決事項」に行を足していない。** これは未決ではなく決着である。

**Gradle プロジェクトの初期化に着手していない。** 作業順序 1 は別に起票する。

Refs #11
