### PR TITLE
feat: 受信エンドポイントを立て、署名検証を通ったものだけを受ける

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ docker compose up -d          # PostgreSQL
 ./gradlew flywayMigrate       # スキーマ適用（jOOQ codegen の前提）
 ./gradlew jooqCodegen         # jOOQ コード生成。通っていないと永続化層はコンパイルできない
 ./gradlew build
-./gradlew bootRun
+SENDGRID_WEBHOOK_PUBLIC_KEY=<SendGrid が配る公開鍵> ./gradlew bootRun
 ```
 
 SendGrid は公開 URL にしか POST しないため、ローカル開発では
@@ -134,6 +134,10 @@ ngrok / Cloudflare Tunnel などでトンネルを張ってください。
 SendGrid 管理画面の `Settings > Mail Settings > Signed Event Webhook Requests`
 で署名検証を有効化すると表示されます。
 Suppression API との突き合わせも動かす場合は `sendgrid.api.key` が追加で要ります。
+
+**既定値は置いていないので、鍵を渡さないと起動しません。** 空で起動できるようにすると、
+設定を忘れたまま全イベントを 403 で弾き続けることになり、それは「解こうとしている問題」が挙げた
+**最も気づきにくい障害**と同じ形になります——通知は 1 通も飛ばず、ログも静かなままです。
 
 > **順序に注意:** 受信側を検証対応にしてから SendGrid 側で有効化してください。
 > 逆にすると全イベントが 403 で弾かれます。

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -74,7 +74,10 @@
 
 9. **`SuppressionReconciler`** — SendGrid API はテストではスタブ化
 
-10. **`SecurityConfig`** — 各チェーンの疎通テスト
+10. **`SecurityConfig`** — 各チェーンの疎通テスト。
+    **webhook と app の 2 本は 6 で先に置いた**（#32）。ここで足すのは oauth チェーンである。
+    6 を待たせなかったのは、**Security が既定のままでは受信エンドポイントが
+    CSRF と認証で弾かれ、README「動かす」が通らないまま残る**ためである
 
 11. **`docs/design.md`** — 設計判断の理由を記録。
     **これはリファレンス実装の中核成果物**。実装のついでではなく独立したタスク

--- a/src/main/kotlin/io/propagandist/recibir/config/SecurityConfig.kt
+++ b/src/main/kotlin/io/propagandist/recibir/config/SecurityConfig.kt
@@ -1,0 +1,65 @@
+package io.propagandist.recibir.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * フィルタチェーンを用途ごとに分ける。
+ *
+ * 分け方の正本は `docs/SPEC.md` §4.6 である。同節は 3 本を挙げているが、
+ * ここにあるのは webhook と app の 2 本で、**oauth チェーンはまだ無い**
+ * （`docs/HANDOVER.md` の作業順序 10）。
+ */
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+    /**
+     * 受信口のチェーン。**認証は署名検証が担う**ので、ここでは誰でも通す。
+     *
+     * `csrf` を切るのは、SendGrid がトークンを持たないためである。
+     * セッションを作らないのは、**1 回きりの POST に状態が要らない**ため。
+     */
+    @Bean
+    @Order(1)
+    fun webhookFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            securityMatcher(WEBHOOK_PATHS)
+            csrf { disable() }
+            sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
+            authorizeHttpRequests { authorize(anyRequest, permitAll) }
+        }
+        return http.build()
+    }
+
+    /**
+     * 受信口**以外**のチェーン。
+     *
+     * **上のチェーンだけにしない。** `securityMatcher` を持つチェーンを 1 本だけ置くと、
+     * そのパターンに当たらないリクエストは**どのチェーンにも入らず、Security を素通りする**。
+     * 今は守る対象が無くても、エンドポイントを足した日に穴が開く。
+     * このリポジトリは分類 A である（`CLAUDE.md`「セキュリティ」）。
+     *
+     * **認証方式を選んでいない。** ここに `httpBasic` や `formLogin` を足すと、
+     * 誰も使わない認証機構と、その設定項目が増える（`docs/SPEC.md` §5）。
+     * 通さないことだけを決めてある。
+     */
+    @Bean
+    @Order(2)
+    fun appFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            authorizeHttpRequests { authorize(anyRequest, authenticated) }
+        }
+        return http.build()
+    }
+
+    private companion object {
+        /** `docs/SPEC.md` §4.6 の対象。受信パスそのものは `SendGridWebhookController.PATH`。 */
+        const val WEBHOOK_PATHS = "/webhooks/sendgrid/**"
+    }
+}

--- a/src/main/kotlin/io/propagandist/recibir/webhook/SendGridEvent.kt
+++ b/src/main/kotlin/io/propagandist/recibir/webhook/SendGridEvent.kt
@@ -1,0 +1,42 @@
+package io.propagandist.recibir.webhook
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * SendGrid が POST してくるイベント配列の要素 1 件。
+ *
+ * カラムとの対応は `docs/SPEC.md` §3.1 が正本である。**射影は取り回しのためであって、
+ * 永続化の正本ではない**——生 JSON は `sendgrid_event.payload` にそのまま入る
+ * （`CLAUDE.md`「絶対に変更しないこと」4）。
+ *
+ * **この型で受信ボディを受け取らない。** 署名の検証対象は生バイト列であり、
+ * JSON として往復させると通らなくなる（`docs/repository-layout.md` 観点 3）。
+ * 受信は [SendGridWebhookController] が `ByteArray` で行い、この型を使うのは投入側である。
+ *
+ * @property sgEventId SendGrid が振る一意な ID。`sendgrid_event` の冪等キーになる
+ * @property sgMessageId 接尾辞が付いたまま保持する。送信時の `X-Message-Id` とは一致しない（README 参照）
+ * @property smtpId 受信 JSON でのキーは `smtp-id`
+ * @property bounceType 受信 JSON でのキーは `type`。`bounce` / `blocked`
+ * @property jobId 送信時に `custom_args` へ入れた値。SendGrid はこれをイベントの直下へ展開して送る
+ * @property timestamp イベントの発生時刻（エポック秒）。**変換しない理由は下記**
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SendGridEvent(
+    @JsonProperty("sg_event_id") val sgEventId: String,
+    val email: String,
+    val event: String,
+    /**
+     * **`Instant` にしない。** `Instant.ofEpochSecond` は範囲外の値で `DateTimeException` を投げ、
+     * それは `RuntimeException` 系なので上へ抜ける（#29 で同じ形を踏んだ）。
+     * ここで変換すると、**受信経路の中に落ちる場所ができる**。
+     * `occurred_at` への変換は投入側で行う。
+     */
+    val timestamp: Long,
+    @JsonProperty("sg_message_id") val sgMessageId: String? = null,
+    @JsonProperty("smtp-id") val smtpId: String? = null,
+    @JsonProperty("type") val bounceType: String? = null,
+    val reason: String? = null,
+    val status: String? = null,
+    @JsonProperty("job_id") val jobId: String? = null,
+)

--- a/src/main/kotlin/io/propagandist/recibir/webhook/SendGridWebhookConfiguration.kt
+++ b/src/main/kotlin/io/propagandist/recibir/webhook/SendGridWebhookConfiguration.kt
@@ -1,0 +1,28 @@
+package io.propagandist.recibir.webhook
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 受信まわりの Bean を組み立てる。
+ *
+ * **[SendGridSignatureVerifier] に `@Component` を付けない。** あの型は今のところ
+ * Spring に依存していない。**このリポジトリは読んで持っていかれることが目的**なので、
+ * 検証器は素のまま残し、フレームワークとの接続はここに閉じる。
+ */
+@Configuration
+class SendGridWebhookConfiguration {
+    /**
+     * 公開鍵を設定から読み、検証器を組み立てる。
+     *
+     * **既定値を書かない。** 空文字を既定にすると、
+     * 鍵の設定を忘れたまま起動でき、**全イベントが 403 で弾かれるのに何も落ちない**状態になる
+     * ——README が「最も気づきにくい障害」と呼ぶ形そのものである。
+     * 解決できなければ起動が止まるほうがよい。
+     */
+    @Bean
+    fun sendGridSignatureVerifier(
+        @Value("\${sendgrid.webhook.public-key}") publicKeyBase64: String,
+    ): SendGridSignatureVerifier = SendGridSignatureVerifier(publicKeyBase64)
+}

--- a/src/main/kotlin/io/propagandist/recibir/webhook/SendGridWebhookController.kt
+++ b/src/main/kotlin/io/propagandist/recibir/webhook/SendGridWebhookController.kt
@@ -1,0 +1,61 @@
+package io.propagandist.recibir.webhook
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * SendGrid Event Webhook の受信口。
+ *
+ * 応答の対応表は `docs/SPEC.md` §4.2 が正本である。ここが持つのは署名検証だけで、
+ * **通ったものを 200、通らなかったものを 403 に倒す**。
+ * 生イベントの投入は後から足す（`docs/HANDOVER.md` の作業順序 7）。
+ *
+ * **JSON をパースしない。** `payload` に入れるのは生ノードであり（同 §4.3）、
+ * パースの結果を要るのは投入側である。ここでパースすると同じ木を 2 回作ることになる。
+ */
+@RestController
+class SendGridWebhookController(
+    private val verifier: SendGridSignatureVerifier,
+) {
+    /**
+     * イベント配列を受け取る。
+     *
+     * **ヘッダとボディをどれも必須にしていない。** 必須にすると、欠けたリクエストが
+     * 400 になって 403 と分かれる——**応答の違いは、そのまま入力の分類器になる**
+     * （`docs/repository-layout.md`「11' を落とせない理由」と同じ形）。
+     * 欠けているものは、署名が合わないのと同じく 403 に倒す。
+     *
+     * **`consumes` も絞っていない。** 絞ると `Content-Type` 違いが 415 になり、これも分かれる。
+     * **署名検証より手前に分岐を作らない。**
+     */
+    @PostMapping(PATH)
+    fun receive(
+        @RequestHeader(SIGNATURE_HEADER, required = false) signature: String?,
+        @RequestHeader(TIMESTAMP_HEADER, required = false) timestamp: String?,
+        @RequestBody(required = false) body: ByteArray?,
+    ): ResponseEntity<Void> {
+        if (signature == null || timestamp == null || body == null) return forbidden()
+        if (!verifier.verify(signature, timestamp, body)) return forbidden()
+        return ResponseEntity.ok().build()
+    }
+
+    /**
+     * 403 を、**ボディなしで**返す。
+     *
+     * 失敗理由を書かない（`CLAUDE.md`「絶対に変更しないこと」3）。
+     * 署名不正・不正 Base64・不正 DER・タイムスタンプ範囲外は、外からは区別が付かない。
+     */
+    private fun forbidden(): ResponseEntity<Void> = ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+
+    companion object {
+        /** 受信パス。`config/SecurityConfig` の webhook チェーンが覆う範囲に入る。 */
+        const val PATH = "/webhooks/sendgrid/events"
+
+        const val SIGNATURE_HEADER = "X-Twilio-Email-Event-Webhook-Signature"
+        const val TIMESTAMP_HEADER = "X-Twilio-Email-Event-Webhook-Timestamp"
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,13 @@ spring:
     url: jdbc:postgresql://localhost:15432/recibir
     username: recibir
     password: recibir
+
+# 受信に必要な設定はこれだけである（docs/SPEC.md §5）。
+# 値は SendGrid の管理画面 Settings > Mail Settings > Signed Event Webhook Requests に出る。
+#
+# 既定値を書かない。空を既定にすると鍵を設定し忘れたまま起動でき、
+# 全イベントが 403 で弾かれるのに何も落ちない状態になる（README「最も気づきにくい障害」）。
+# 環境変数が無ければ、ここで起動が止まる。
+sendgrid:
+  webhook:
+    public-key: ${SENDGRID_WEBHOOK_PUBLIC_KEY}

--- a/src/test/kotlin/io/propagandist/recibir/webhook/SendGridEventTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/SendGridEventTest.kt
@@ -1,0 +1,104 @@
+package io.propagandist.recibir.webhook
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import tools.jackson.databind.json.JsonMapper
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * `SendGridEvent` が、SendGrid の送ってくる形の JSON から読めることを確かめる。
+ *
+ * **マッパーを手で組まない。** Boot が組み立てたものを注入して、
+ * **本番と同じ設定で読めること**を見る（`CLAUDE.md`「Spring Boot 4 の注意点」）。
+ *
+ * この型で受信ボディを受け取るわけではない（署名検証には生バイト列が要る）。
+ * ここで固定しているのは、**投入側が使う射影の形**である。
+ */
+@JsonTest
+class SendGridEventTest {
+    @Autowired
+    private lateinit var jsonMapper: JsonMapper
+
+    @Test
+    fun `キー名が Kotlin の命名と違うフィールドを拾う`() {
+        val json =
+            """
+            {
+              "sg_event_id": "ZGVsaXZlcmVk",
+              "sg_message_id": "abc123.filterdrecv-aaa-bbb.1",
+              "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+              "email": "user@example.com",
+              "event": "bounce",
+              "type": "blocked",
+              "reason": "550 5.1.1 The email account does not exist",
+              "status": "5.1.1",
+              "job_id": "job-42",
+              "timestamp": 1798723200
+            }
+            """.trimIndent()
+
+        val event = jsonMapper.readValue(json, SendGridEvent::class.java)
+
+        assertEquals("ZGVsaXZlcmVk", event.sgEventId)
+        // 接尾辞を切らずにそのまま持つ（docs/SPEC.md §3.1）
+        assertEquals("abc123.filterdrecv-aaa-bbb.1", event.sgMessageId)
+        // ハイフンを含むキー。素直に書くと拾えない
+        assertEquals("<14c5d75ce93.dfd.64b469@ismtpd-555>", event.smtpId)
+        // 受信 JSON では type。カラム名は bounce_type
+        assertEquals("blocked", event.bounceType)
+        assertEquals("job-42", event.jobId)
+    }
+
+    @Test
+    fun `知らないフィールドが増えても落ちない`() {
+        // SendGrid は予告なくフィールドを足す（README「生 JSON を捨てない」）。
+        // 落ちると、その日から受信が全部止まる
+        val json =
+            """
+            {
+              "sg_event_id": "abc",
+              "email": "user@example.com",
+              "event": "delivered",
+              "timestamp": 1798723200,
+              "category": ["cat facts"],
+              "unknown_field_added_later": {"nested": true}
+            }
+            """.trimIndent()
+
+        val event = jsonMapper.readValue(json, SendGridEvent::class.java)
+
+        assertEquals("delivered", event.event)
+        assertNull(event.reason)
+    }
+
+    @Test
+    fun `配列としてまとめて読める`() {
+        val json =
+            """
+            [
+              {"sg_event_id": "a", "email": "user@example.com", "event": "processed", "timestamp": 1798723200},
+              {"sg_event_id": "b", "email": "user@example.com", "event": "delivered", "timestamp": 1798723260}
+            ]
+            """.trimIndent()
+
+        val events = jsonMapper.readValue(json, Array<SendGridEvent>::class.java)
+
+        assertEquals(listOf("a", "b"), events.map { it.sgEventId })
+    }
+
+    @Test
+    fun `Instant の範囲を超える timestamp でも読める`() {
+        // Long のまま持っている効果がここに出る。Instant にしていると、
+        // 変換で DateTimeException が出て受信経路の中で落ちる（#29 と同じ形）
+        val json =
+            """
+            {"sg_event_id": "a", "email": "user@example.com", "event": "delivered", "timestamp": 999999999999999999}
+            """.trimIndent()
+
+        val event = jsonMapper.readValue(json, SendGridEvent::class.java)
+
+        assertEquals(999999999999999999L, event.timestamp)
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookConfigurationTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookConfigurationTest.kt
@@ -1,0 +1,39 @@
+package io.propagandist.recibir.webhook
+
+import io.propagandist.recibir.support.TestKeyPair
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * 公開鍵の設定が無いときに、**起動が止まること**を確かめる。
+ *
+ * 落ちてほしい理由は `SendGridWebhookConfiguration` の KDoc にある——
+ * **黙って起動されるほうが困る**。鍵が無いまま動くと全イベントが 403 になり、
+ * それは「配信が全部成功している」と見分けが付かない。
+ */
+class SendGridWebhookConfigurationTest {
+    private val runner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(PropertyPlaceholderAutoConfiguration::class.java))
+            .withUserConfiguration(SendGridWebhookConfiguration::class.java)
+
+    @Test
+    fun `公開鍵が設定されていないと起動に失敗する`() {
+        runner.run { context -> assertNotNull(context.startupFailure) }
+    }
+
+    @Test
+    fun `公開鍵があれば検証器が組み上がる`() {
+        val keyPair = TestKeyPair.generate()
+        runner
+            .withPropertyValues("sendgrid.webhook.public-key=${TestKeyPair.publicKeyBase64(keyPair)}")
+            .run { context ->
+                assertNull(context.startupFailure)
+                context.getBean(SendGridSignatureVerifier::class.java)
+            }
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookControllerTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookControllerTest.kt
@@ -1,0 +1,125 @@
+package io.propagandist.recibir.webhook
+
+import io.propagandist.recibir.config.SecurityConfig
+import io.propagandist.recibir.support.TestKeyPair
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.security.KeyPair
+import java.time.Instant
+import kotlin.test.assertTrue
+
+/**
+ * 受信口の応答を確かめる。対応表の正本は `docs/SPEC.md` §4.2 である。
+ *
+ * **外部を使わない。** 鍵ペアはその場で生成し、公開鍵を設定へ流し込んで**本番と同じ配線**を通す
+ * ——検証器を差し替えると、`SendGridWebhookConfiguration` が繋がっていることを確かめられない。
+ *
+ * 見ているのは大きく 2 つある。**通ったものが 200 になること**と、
+ * **通らなかったものが 403 に揃うこと**である。後者は 400 や 415 と分かれてはいけない。
+ */
+@WebMvcTest(SendGridWebhookController::class)
+@Import(SendGridWebhookConfiguration::class, SecurityConfig::class)
+class SendGridWebhookControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    private val timestamp = Instant.now().epochSecond.toString()
+    private val body = """[{"email":"user@example.com","event":"delivered","sg_event_id":"abc"}]""".toByteArray()
+
+    /** 既定は「すべて正しい」形で、各テストは崩したい 1 つだけを指定する。 */
+    private fun send(
+        signature: String? = TestKeyPair.sign(KEY_PAIR, timestamp, body),
+        stamp: String? = timestamp,
+        payload: ByteArray? = body,
+        type: MediaType? = MediaType.APPLICATION_JSON,
+    ) = mockMvc.post(SendGridWebhookController.PATH) {
+        signature?.let { header(SendGridWebhookController.SIGNATURE_HEADER, it) }
+        stamp?.let { header(SendGridWebhookController.TIMESTAMP_HEADER, it) }
+        type?.let { contentType = it }
+        payload?.let { content = it }
+    }
+
+    @Test
+    fun `正しい署名なら 200 を返す`() {
+        send().andExpect { status { isOk() } }
+    }
+
+    @Test
+    fun `署名が合わないと 403 で、ボディは空`() {
+        val tampered = body.copyOf().also { it[it.lastIndex] = '!'.code.toByte() }
+        send(payload = tampered).andExpect {
+            status { isForbidden() }
+            // 失敗理由を書かない（CLAUDE.md「絶対に変更しないこと」3）
+            content { string("") }
+        }
+    }
+
+    // ここから 3 本は、素朴に実装すると 400 になるところである。
+    // 400 と 403 が分かれると、外から入力の種類を当てられる（docs/repository-layout.md「11' を落とせない理由」）。
+
+    @Test
+    fun `署名ヘッダが無くても 403 で、400 にならない`() {
+        send(signature = null).andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    fun `timestamp ヘッダが無くても 403 で、400 にならない`() {
+        send(stamp = null).andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    fun `ボディが無くても 403 で、400 にならない`() {
+        send(payload = null).andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    fun `Content-Type が JSON でなくても、落ちるときは 403 で 415 にならない`() {
+        val tampered = body.copyOf().also { it[it.lastIndex] = '!'.code.toByte() }
+        send(payload = tampered, type = MediaType.TEXT_PLAIN).andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    fun `Content-Type を見ていないので、署名さえ合えば JSON でなくても通る`() {
+        // consumes を絞っていないことの裏返し。SendGrid が何を送っても、判断は署名だけで決まる
+        send(type = MediaType.TEXT_PLAIN).andExpect { status { isOk() } }
+    }
+
+    @Test
+    fun `受信口の外は、認証なしでは通らない`() {
+        // webhook チェーン 1 本だけだと、ここが Security を素通りする（config/SecurityConfig）。
+        // 素通りするとハンドラが無いので 404 になる——**そこで見分ける**。
+        //
+        // 番号そのものは固定しない。app チェーンは認証方式を選んでいないので、
+        // 返るのは entry point 次第で決まる（2026-08-28 実測では 403）。
+        // ここで守りたいのは「ハンドラまで届かないこと」であって、番号ではない。
+        val status =
+            mockMvc
+                .get("/anything")
+                .andReturn()
+                .response.status
+        assertTrue(status in setOf(401, 403), "認証なしで受信口の外へ届いている: $status")
+    }
+
+    companion object {
+        /** 鍵はテストの中で作る。検証をスキップする経路は作らない（`CLAUDE.md`「絶対に変更しないこと」1）。 */
+        val KEY_PAIR: KeyPair = TestKeyPair.generate()
+
+        /**
+         * 公開鍵は毎回変わるので、静的なプロパティでは渡せない。
+         * ここで流し込むことで、`application.yml` と同じキーから本番と同じ経路で読ませる。
+         */
+        @JvmStatic
+        @DynamicPropertySource
+        fun publicKey(registry: DynamicPropertyRegistry) {
+            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(KEY_PAIR) }
+        }
+    }
+}


### PR DESCRIPTION
#32 の実装。`docs/HANDOVER.md` の作業順序 6。

**判断とその理由は issue 本文にある。ここへ写さない。** 以下は、実装して分かったことと、
issue の時点では決めていなかったことだけである。

## 実走で分かったこと

### app チェーンは 403 を返す（2026-08-28 実測）

issue では「番号を書き込まない」としていた。実測は 403 である——`httpBasic` も `formLogin` も
置いていないので、entry point が `Http403ForbiddenEntryPoint` になる。

**テストのアサーションは 401 か 403 かで見ている。** 番号を固定すると、Security の版が上がって
401 になった日に、守りたいことが壊れていないのに落ちる。**素通りするとハンドラが無いので
404 になる**ので、見分けはそれで足りる。

### 公開鍵が無いと `PlaceholderResolutionException` で止まる（同日実測）

```
Could not resolve placeholder 'SENDGRID_WEBHOOK_PUBLIC_KEY' in value "${SENDGRID_WEBHOOK_PUBLIC_KEY}"
```

**エラーが環境変数名を名指しする。** 設定漏れは読めば分かる形で落ちる。

### README「動かす」が、そのままでは通らなかった

`./gradlew bootRun` だけでは上記で止まる。**手順が通らない状態だった**ので、
鍵を渡す形に直した（4 本目のコミット）。issue の対象範囲には README を挙げていなかったが、
受け入れ基準の目視項目が「その順序で実際に通るか」を求めている。

### Kotlin のブロックコメントはネストする

KDoc に `/webhooks/sendgrid/**` と書くと、その中の `/*` が新しいコメントを開き、`*/` 1 つでは
閉じない。**エラーはファイル末尾で「Unclosed comment」として出る**ので、原因が分かりにくい。

## issue から変えた点

**受け入れ基準の「`Content-Type` が JSON でないときも 403」を 2 つに分けた。**
署名さえ合えば、Content-Type が違っても 200 が返る——`consumes` を絞っていないことの裏返しで、
これも残す価値がある。403 になるのは署名が合わないときである。テストは両方持っている。

## 確かめたこと

- `./gradlew build` が緑。テストは 35 本で、**DB もネットワークも SendGrid アカウントも要らない**
- `docs/repository-layout.md`「履歴」のチェック——API キー・実在アドレス・手元の絶対パスは無い。
  テストに出るのは `user@example.com` と SendGrid の `smtp-id` の形だけである

`openssl` で作った EC P-256 鍵ペアで `bootRun` へ curl を打ち、実地でも確認した（2026-08-28 実測）。

| 送ったもの | 返り |
|---|---|
| 正しい署名 | 200、ボディなし |
| ボディを 1 バイト変える | 403、ボディなし |
| 署名ヘッダ無し | 403（**400 ではない**） |
| `Content-Type: text/plain` ＋ 正しい署名 | 200（**415 ではない**） |
| 受信口の外（`/anything`） | 403 |

## まだ入っていないもの

- **生イベントの投入**（作業順序 7）。コントローラは署名検証で終わっている
- **不正 JSON を 200 で受け切って退避**（`docs/SPEC.md` §4.2 の 3 行目）。退避先のテーブルが
  §3 に無く、アラートの実体も未定義である。#5 が同じ点を挙げている
- **構造化ログ**（#5）
- **oauth チェーン**（作業順序 10）

Closes #32
