### PR TITLE
feat: 受信イベントから email_address_state を組み上げ、送れないアドレスを知らせる

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -139,6 +139,11 @@ Kotlin の data class では use-site target を明示しないと
 
 - [ ] ライセンスヘッダを全ファイルに入れるか、`NOTICE` に集約するか
 - [ ] `SuppressionReconciler` の実行時刻
+- [ ] `SuppressionReconciler` が付けた `reason_code` を、`EventProjector` が上書きしてよいか。
+      **イベントが 1 件も無い状態行は触らない**（射影は `sendgrid_event` に出てくる
+      アドレスだけを回す）。ただし**イベントもある**アドレスに `invalid` が付いていた場合は、
+      次の射影で消える。`docs/SPEC.md` §4.5 は「SendGrid 側を正とする」と書いており、
+      **どちらを採るかは作業順序 9 で決まる**
 
 ## やらないこと（再確認）
 

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -138,7 +138,6 @@ Kotlin の data class では use-site target を明示しないと
 ## 未決事項
 
 - [ ] ライセンスヘッダを全ファイルに入れるか、`NOTICE` に集約するか
-- [ ] `EventProjector` のポーリング間隔（既定値を決める）
 - [ ] `SuppressionReconciler` の実行時刻
 
 ## やらないこと（再確認）

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -117,12 +117,23 @@ ECDSA（`SHA256withECDSA`、EC P-256）による署名検証。
 
 `sendgrid_event` から `email_address_state` を再構築する非同期処理。
 
-- 未処理イベントのポーリング（`@Scheduled`）で開始する。
-  月数万通規模ではメッセージキューは不要
+- **直近に受信したイベント**のアドレスを `@Scheduled` のポーリングで拾う。
+  間隔は 1 分、窓は `received_at` で 10 分。月数万通規模ではメッセージキューは不要
+- **処理済みを記録しない。** 状態は対象アドレスの全イベントから決まるので、
+  同じアドレスを何度作り直しても結果は同じである。**窓が間隔より長いのは無駄ではない**
+  ——1 回失敗しても、次の回で拾える
 - **単発イベントで上書きしない。** 対象アドレスの全イベントから状態を決定する
 - 状態決定の優先度:
-  `spamreport` > `bounce`(type=bounce) > `dropped` > `deferred` > `delivered`
-- 全件再構築を行うコマンドを用意する（解釈ロジック修正時の再処理用）
+  `spamreport` > `bounce`(type=bounce) > `unsubscribe` > `dropped` > `deferred` > `delivered`
+- **`unsubscribe` は `dropped` より前に置く。** `dropped` は「抑制リストに載っていたので
+  捨てた」という**結果**で、`unsubscribe` はその**原因**である。
+  `dropped` しか無いアドレスには `reason_code` を付けない——理由は他のイベントが持つ
+- **`deferred` と `blocked`（`bounce` の `type`）では `sendable` を落とさない。**
+  どちらも一時的な失敗で、`soft_bounce_count` と `last_failure_at` だけが動く
+- **`unsubscribe` では `last_failure_at` を更新しない。** 購読解除は失敗ではない
+- **`group_unsubscribe` / `group_resubscribe` は状態の外に置く。**
+  グループ単位の購読可否は SendGrid 側が持ち、このテーブルとは粒度が違う
+- `--rebuild-all` を付けて起動すると全件を作り直す（解釈ロジック修正時の再処理用）
 
 ### 4.5 `SuppressionReconciler`（`reconcile/`）
 
@@ -182,8 +193,9 @@ OAuth 有効時の `AuthenticationEntryPoint` は、**レスポンスボディ�
 監視基盤があれば、アプリ側の実装は要らない。これが無いと、**通知が来ないことが
 「配信が全部成功している」なのか「Webhook が全部弾かれている」なのか区別できない。**
 
-**メールアドレスはマスクする。** ローカル部を伏せ、ドメインは残す（`u***@example.com`）。
+**メールアドレスはマスクする。** ローカル部を伏せ、ドメインは残す（`***@example.com`）。
 特定ドメインへの集中的な配信不能をログだけで読むためで、個人の特定は DB を引いて行う。
+**ローカル部は 1 文字も残さない**——先頭を残す形にすると、1 文字のローカル部がそのまま全部出る。
 **`webhook.rejected` と `event.unparseable` には載せない**——検証を通っていない入力と、
 解釈できなかった入力は、何が入っているか分からない。
 

--- a/src/main/kotlin/io/propagandist/recibir/config/SchedulingConfig.kt
+++ b/src/main/kotlin/io/propagandist/recibir/config/SchedulingConfig.kt
@@ -1,0 +1,18 @@
+package io.propagandist.recibir.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+/**
+ * `@Scheduled` を有効にする。
+ *
+ * 射影は `@Scheduled` のポーリングで動く（`docs/SPEC.md` §4.4）。
+ * **月数万通規模ではメッセージキューを持ち込む理由が無い。**
+ *
+ * **Executor の設定を置いていない。** Boot の既定は 1 本のスレッドで、いま定期実行するのは
+ * `EventProjector` だけである。日次の突き合わせ（同 §4.5）が入った日に、
+ * 同時に走らせる必要が出たら決める——**先に用意すると、使われない設定だけが残る。**
+ */
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/src/main/kotlin/io/propagandist/recibir/event/AddressState.kt
+++ b/src/main/kotlin/io/propagandist/recibir/event/AddressState.kt
@@ -1,0 +1,125 @@
+package io.propagandist.recibir.event
+
+import java.time.OffsetDateTime
+
+/**
+ * 射影の入力になるイベント 1 件。
+ *
+ * `sendgrid_event` から読むのはこの 3 つの列だけである。**`payload` は開かない**——
+ * 状態を決めるのに要るものは V1 の時点で列に出してあり、生 JSON を読み直すと、
+ * 同じ判断が列とパースの 2 か所に散る。
+ *
+ * **[io.propagandist.recibir.webhook.SendGridEvent] を使い回していない。**
+ * あちらは受信 JSON の射影で、こちらは DB から読む側である。同じ型にすると、
+ * 投入側がフィールドを足した日に、射影の入力が黙って変わる。
+ *
+ * @property event `sendgrid_event.event`。delivered / bounce / dropped など
+ * @property bounceType `sendgrid_event.bounce_type`。`bounce` イベントの `type`
+ * @property occurredAt SendGrid 側の発生時刻。`received_at` ではない
+ */
+data class AddressEvent(
+    val event: String,
+    val bounceType: String?,
+    val occurredAt: OffsetDateTime,
+)
+
+/**
+ * 1 アドレス分の導出状態。`email_address_state` の 1 行に対応する（`docs/SPEC.md` §3.2）。
+ *
+ * @property sendable このアドレスへ送ってよいか
+ * @property reasonCode hard_bounce / spam_report / unsubscribe。`invalid` を付けるのは
+ *   `SuppressionReconciler` であって、この層ではない（同 §4.5）
+ * @property lastFailureAt 最後に失敗した時刻。**購読解除は含まない**
+ * @property softBounceCount 一時的な不達の件数
+ */
+data class AddressState(
+    val sendable: Boolean,
+    val reasonCode: String?,
+    val lastFailureAt: OffsetDateTime?,
+    val softBounceCount: Int,
+) {
+    companion object {
+        /**
+         * 対象アドレスの**全イベント**から状態を決める。
+         *
+         * **単発のイベントで遷移させない**（`CLAUDE.md`「絶対に変更しないこと」5）。
+         * 下の `when` が見ているのは「その種類が 1 件でもあるか」だけで、
+         * **並び順にも件数にも依存しない**——だから `delivered` の後に `processed` が届いても、
+         * 同じイベントを二度読んでも、結果は変わらない。呼び出し側が `ORDER BY` を
+         * 書いていないのは、この性質の裏返しである。
+         *
+         * ## 見ないイベント
+         *
+         * **無視も判断なので、ここに書く。書いていないと後から足される。**
+         *
+         * - `group_unsubscribe` / `group_resubscribe` — **グループ単位の購読可否は
+         *   SendGrid 側が持つ。** この状態が答えるのは「このアドレスへ送ってよいか」であって、
+         *   粒度が違う。グループの解除で全体を止めると、**送れるはずのメールが送れなくなる。**
+         *   `group_resubscribe` が存在することは、**この状態が単調でない**ことも意味する——
+         *   下の優先度は一度落ちたら戻らない形なので、グループ単位の出入りは最初から表現できない
+         * - `open` / `click` — 配信の可否と関係が無い
+         * - `account_status_change` — **送信者アカウント**の状態であって、宛先アドレスの話ではない
+         */
+        fun from(events: List<AddressEvent>): AddressState {
+            // 優先度は docs/SPEC.md §4.4。上から順に見て、最初に当たったものを採る
+            val (sendable, reasonCode) =
+                when {
+                    events.any { it.event == SPAMREPORT } -> false to "spam_report"
+
+                    events.any { it.isHardBounce } -> false to "hard_bounce"
+
+                    // dropped より前に置く。dropped は「抑制リストに載っていたので捨てた」という
+                    // **結果**で、unsubscribe はその**原因**である。原因のほうが情報を持つ
+                    events.any { it.event == UNSUBSCRIBE } -> false to "unsubscribe"
+
+                    // 送れないことは分かるが、**理由は他のイベントが持つ。**
+                    // reason の文字列（"Bounced Address" など）を読んで振り分けない
+                    // ——SendGrid が文言を変えた日に、黙って壊れる。原因のイベントを
+                    // 取りこぼしていた場合は SuppressionReconciler が補完する（同 §4.5）
+                    events.any { it.event == DROPPED } -> false to null
+
+                    else -> true to null
+                }
+            return AddressState(
+                sendable = sendable,
+                reasonCode = reasonCode,
+                lastFailureAt = events.filter { it.isFailure }.maxOfOrNull { it.occurredAt },
+                softBounceCount = events.count { it.isSoftBounce },
+            )
+        }
+    }
+}
+
+private const val SPAMREPORT = "spamreport"
+private const val BOUNCE = "bounce"
+private const val DROPPED = "dropped"
+private const val DEFERRED = "deferred"
+private const val UNSUBSCRIBE = "unsubscribe"
+
+/** `bounce` イベントの `type`。**受け取り側が一時的に拒んだ**という意味で、恒久的な不達ではない。 */
+private const val BLOCKED = "blocked"
+
+/**
+ * 恒久的な不達。
+ *
+ * **`blocked` でないことで判定している。** `docs/SPEC.md` §4.4 は `bounce`(type=bounce) と
+ * 書いているが、そのとおり `== "bounce"` で書くと、**`type` が落ちた日に恒久的な不達を
+ * 一時扱いにする**——届かないアドレスへ送り続けることになる。
+ * 分類できないものは、送らない側へ倒す。
+ */
+private val AddressEvent.isHardBounce: Boolean
+    get() = event == BOUNCE && bounceType != BLOCKED
+
+/**
+ * 一時的な不達。**`sendable` は落とさない**——恒久的な不達と混ぜない。
+ */
+private val AddressEvent.isSoftBounce: Boolean
+    get() = event == DEFERRED || (event == BOUNCE && bounceType == BLOCKED)
+
+/**
+ * `last_failure_at` を動かすもの。
+ *
+ * **`unsubscribe` は入らない。** 購読解除は失敗ではない——**列名が意味するものを守る。**
+ */
+private val AddressEvent.isFailure: Boolean
+    get() = isHardBounce || isSoftBounce || event == SPAMREPORT || event == DROPPED

--- a/src/main/kotlin/io/propagandist/recibir/event/EventProjector.kt
+++ b/src/main/kotlin/io/propagandist/recibir/event/EventProjector.kt
@@ -1,0 +1,188 @@
+package io.propagandist.recibir.event
+
+import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
+import io.propagandist.jooq.Tables.SENDGRID_EVENT
+import io.propagandist.jooq.tables.records.EmailAddressStateRecord
+import org.jooq.DSLContext
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.concurrent.TimeUnit
+
+/**
+ * `sendgrid_event` から `email_address_state` を作り直す（`docs/SPEC.md` §4.4）。
+ *
+ * 状態をどう決めるかは [AddressState] が持つ。ここが持つのは**どれを・いつ作り直すか**である。
+ *
+ * ## 処理済みを追わない
+ *
+ * **「未処理イベント」を記録しない。** 状態は対象アドレスの全イベントから決まるので、
+ * **同じアドレスを何度作り直しても結果は同じ**である。だから直近に受信したイベントの
+ * アドレスを集めて作り直せば足りる。
+ *
+ * 窓（[WINDOW]）はポーリング間隔より長い。**重なるのは無駄ではなく、1 回失敗しても
+ * 次の回で拾えるということ**である。長く止まった後の取りこぼしは [rebuildAll] が受け皿になる。
+ *
+ * 処理済みの id を持つテーブルは足していない。**捨てて作り直せない三つ目のテーブル**が
+ * 増えるためで、`sendgrid_event` に処理済みの列を足さないのも同じ理由である
+ * （正本を append-only に保てなくなる。同 §3.1）。
+ *
+ * **窓も間隔も設定項目にしない**（同 §5）。署名検証の許容ずれと同じ扱いである。
+ */
+@Service
+class EventProjector(
+    private val dsl: DSLContext,
+) {
+    /**
+     * 直近の窓に受信したイベントのアドレスを作り直す。
+     *
+     * **`received_at` で絞る。** `occurred_at` ではない——遅れて届いたイベントは
+     * SendGrid 側の時刻が古いので、そちらで絞ると窓から外れて永久に拾えなくなる。
+     */
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    fun projectRecent() {
+        // 窓の起点はアプリの時計で作る。DB の時計と 2 つになるが、**そのずれは窓の重なりが
+        // 吸収する**——重なりを取ってあるのは、そもそも 1 回失敗しても次で拾うためである
+        val since = OffsetDateTime.now().minus(WINDOW)
+        dsl
+            .selectDistinct(SENDGRID_EVENT.EMAIL)
+            .from(SENDGRID_EVENT)
+            .where(SENDGRID_EVENT.RECEIVED_AT.ge(since))
+            .fetch(SENDGRID_EVENT.EMAIL)
+            .forEach { project(it) }
+    }
+
+    /**
+     * `sendgrid_event` に出てくる全アドレスを作り直す。**解釈を直した日のためにある。**
+     *
+     * **イベントが 1 件も無い状態行は触らない。** `SuppressionReconciler` が
+     * Suppression API を正として先に立てた行がありうる（`docs/er.md` の多重度 3 行目）。
+     * ここが消すと、Webhook を取りこぼしたアドレスの記録が毎回消えることになる。
+     *
+     * @return 作り直したアドレスの件数
+     */
+    fun rebuildAll(): Int {
+        val emails =
+            dsl
+                .selectDistinct(SENDGRID_EVENT.EMAIL)
+                .from(SENDGRID_EVENT)
+                .fetch(SENDGRID_EVENT.EMAIL)
+        emails.forEach { project(it) }
+        // event キーを持たない素のログにしてある。docs/SPEC.md §4.7 の表は
+        // 運用が監視するものを並べたもので、起動時の 1 回きりの記録はそこに要らない
+        log.info("rebuilt {} addresses", emails.size)
+        return emails.size
+    }
+
+    /**
+     * 1 アドレスを、そのアドレスの**全イベント**から作り直す。
+     *
+     * **`ORDER BY` を書いていない。** [AddressState.from] が並び順に依存しないためで、
+     * 書けば「順序に意味がある」と読まれる。
+     *
+     * **トランザクションを張っていない。** 読みと書きの間に新しいイベントが入っても、
+     * 次のポーリングが窓の重なりで拾い直す。ここで整合を取ろうとすると、
+     * **窓が重なっている理由と二重に手当てすることになる。**
+     */
+    fun project(email: String) {
+        val events =
+            dsl
+                .select(SENDGRID_EVENT.EVENT, SENDGRID_EVENT.BOUNCE_TYPE, SENDGRID_EVENT.OCCURRED_AT)
+                .from(SENDGRID_EVENT)
+                .where(SENDGRID_EVENT.EMAIL.eq(email))
+                .fetch { AddressEvent(it.value1(), it.value2(), it.value3()) }
+
+        val next = AddressState.from(events)
+        val current = dsl.fetchOne(EMAIL_ADDRESS_STATE, EMAIL_ADDRESS_STATE.EMAIL.eq(email))
+        // **変わっていなければ書かない。** 窓が重なる以上、同じアドレスは何度も通る——
+        // 毎回書くと updated_at が 1 分ごとに動き、「いつ状態が変わったか」が読めなくなる。
+        // 下の address.unsendable が毎分出ないのも、この分岐のおかげである
+        if (current != null && current.matches(next)) return
+
+        write(email, next)
+        if (next.sendable) return
+        // **送れなくなったことに気づく手段はこの 1 行である**（#5）。
+        // 出るのは状態が実際に変わったときだけで、全件再構築の直後には全件が出る
+        // ——それは記録として正しい。**通知の抑制は監視基盤の仕事である**（docs/SPEC.md §4.7）
+        log
+            .atWarn()
+            .addKeyValue("event", "address.unsendable")
+            .addKeyValue("email", maskEmail(email))
+            .addKeyValue("reason_code", next.reasonCode)
+            .log("an address became unsendable")
+    }
+
+    /**
+     * 1 行を UPSERT する。
+     *
+     * **同じ record を 2 度渡している。** jOOQ は INSERT の値と ON CONFLICT の更新値を
+     * 別に受けるが、ここでは**全列を導出し直している**ので、どちらも同じ値になる。
+     * 列を並べ直すと、片方に足し忘れる形の壊れ方ができる。
+     */
+    private fun write(
+        email: String,
+        state: AddressState,
+    ) {
+        val record =
+            dsl.newRecord(EMAIL_ADDRESS_STATE).apply {
+                this.email = email
+                sendable = state.sendable
+                reasonCode = state.reasonCode
+                lastFailureAt = state.lastFailureAt
+                softBounceCount = state.softBounceCount
+                // 「状態が変わった時刻」になる。上の分岐が、変わらないときに書かないためである
+                updatedAt = OffsetDateTime.now()
+            }
+        dsl
+            .insertInto(EMAIL_ADDRESS_STATE)
+            .set(record)
+            .onConflict(EMAIL_ADDRESS_STATE.EMAIL)
+            .doUpdate()
+            .set(record)
+            .execute()
+    }
+
+    private companion object {
+        val log = LoggerFactory.getLogger(EventProjector::class.java)
+
+        /**
+         * 直近の窓の広さ。**ポーリング間隔（1 分）より長く取る。**
+         *
+         * 規模の根拠は `docs/SPEC.md` §4.4 の「月数万通規模」で、1 分ごとに数件を読む形になる。
+         */
+        val WINDOW: Duration = Duration.ofMinutes(10)
+    }
+}
+
+/**
+ * 現在の行が、導出した状態と同じかどうか。
+ *
+ * **時刻は `Instant` で比べる。** `timestamptz` が保持するのは瞬間で、返るときのオフセットは
+ * セッションのタイムゾーンに従う。`OffsetDateTime` 同士の `equals` はオフセットまで見るので、
+ * **同じ瞬間を「変わった」と読んでしまう**。
+ */
+private fun EmailAddressStateRecord.matches(state: AddressState): Boolean =
+    sendable == state.sendable &&
+        reasonCode == state.reasonCode &&
+        lastFailureAt?.toInstant() == state.lastFailureAt?.toInstant() &&
+        softBounceCount == state.softBounceCount
+
+/**
+ * ログへ出すために、アドレスのローカル部を伏せる（`docs/SPEC.md` §4.7）。
+ *
+ * **1 文字も残さない。** 先頭の 1 文字を残す形にすると、**1 文字のローカル部がそのまま全部出る。**
+ * ドメインだけ残せば「特定ドメインへの集中的な配信不能」は読めるので、目的は満たす
+ * ——個人の特定は DB を引いて行う。
+ *
+ * **`@` を含まない値も受ける。** `email` 列に何が入るかを決めているのは SendGrid であって、
+ * こちらではない。分けられなければ全部伏せる。区切りを**最後の** `@` で取るのも同じ理由で、
+ * ローカル部に `@` を含む形が来ても、残るのはドメインだけになる。
+ */
+internal fun maskEmail(email: String): String {
+    val at = email.lastIndexOf('@')
+    return if (at < 0) MASK else MASK + email.substring(at)
+}
+
+private const val MASK = "***"

--- a/src/main/kotlin/io/propagandist/recibir/event/RebuildAllRunner.kt
+++ b/src/main/kotlin/io/propagandist/recibir/event/RebuildAllRunner.kt
@@ -1,0 +1,34 @@
+package io.propagandist.recibir.event
+
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+
+/**
+ * `--rebuild-all` が付いていたら、起動時に全件を作り直す（`docs/SPEC.md` §4.4）。
+ *
+ * 解釈を直した日のためにある。`email_address_state` は捨てて作り直せる二次テーブルで、
+ * 作り直す手段が無ければ、直したロジックが過去のイベントに届かない。
+ *
+ * **HTTP のエンドポイントにしていない。** 管理 UI に近づき、同 §2 の「含まない」に触れる。
+ * **設定項目にもしていない**（同 §5）——コマンドライン引数は設定ではなく、
+ * **その 1 回の起動の指示**である。
+ *
+ * **作り直した後も、そのまま起動を続ける。** 終了させる形にすると、起動コマンドへ
+ * 引数が残った日にアプリが二度と上がらなくなる。続ければ、残っていても
+ * 起動が少し遅くなるだけで済む。
+ */
+@Component
+class RebuildAllRunner(
+    private val projector: EventProjector,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments) {
+        if (!args.containsOption(OPTION)) return
+        projector.rebuildAll()
+    }
+
+    private companion object {
+        /** `--rebuild-all`。**接頭辞の `--` は [ApplicationArguments] 側が外して持つ。** */
+        const val OPTION = "rebuild-all"
+    }
+}

--- a/src/main/resources/db/migration/V2__index_received_at.sql
+++ b/src/main/resources/db/migration/V2__index_received_at.sql
@@ -1,0 +1,10 @@
+-- EventProjector は、直近に受信したイベントのアドレスを窓で拾う（docs/SPEC.md §4.4）。
+-- V1 が張った索引は先頭列が email / sg_message_id / job_id のいずれかで、
+-- received_at だけを条件にした検索には効かない。
+--
+-- 窓に入るのは 1 分あたり数件である（同 §4.4 の月数万通規模）。
+-- ただし索引が無ければ、その数件を見つけるために毎分すべての行を走ることになり、
+-- sendgrid_event は append-only なので走る量だけが増え続ける。
+--
+-- DESC で作るのは、窓が「新しい側から一定期間」を切り出す形だからである。
+CREATE INDEX idx_sendgrid_event_received_at ON sendgrid_event (received_at DESC);

--- a/src/test/kotlin/io/propagandist/recibir/event/AddressStateTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/event/AddressStateTest.kt
@@ -1,0 +1,229 @@
+package io.propagandist.recibir.event
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * 状態決定そのものを確かめる。**DB も Spring も要らない。**
+ *
+ * 分けてあるのは、ここが「対象アドレスの全イベントから決まる」という主張の置き場だからである
+ * ——順序の乱れも重複も、入力のリストを並べ替えるだけで書ける。
+ * 窓・書き込み・ログは `EventProjectorTest` が見る。
+ */
+class AddressStateTest {
+    private fun event(
+        event: String,
+        bounceType: String? = null,
+        occurredAt: Long = BASE,
+    ) = AddressEvent(event, bounceType, Instant.ofEpochSecond(occurredAt).atOffset(ZoneOffset.UTC))
+
+    @Test
+    fun `bounce は sendable を落とし、理由は hard_bounce`() {
+        val state = AddressState.from(listOf(event("bounce", bounceType = "bounce")))
+
+        assertFalse(state.sendable)
+        assertEquals("hard_bounce", state.reasonCode)
+    }
+
+    @Test
+    fun `spamreport の理由は spam_report`() {
+        val state = AddressState.from(listOf(event("spamreport")))
+
+        assertFalse(state.sendable)
+        assertEquals("spam_report", state.reasonCode)
+    }
+
+    @Test
+    fun `unsubscribe の理由は unsubscribe`() {
+        // docs/SPEC.md §4.4 の優先度に unsubscribe を足した分（#36）。
+        // §3.2 が要求する reason_code を、足す前の手順では作れなかった
+        val state = AddressState.from(listOf(event("unsubscribe")))
+
+        assertFalse(state.sendable)
+        assertEquals("unsubscribe", state.reasonCode)
+    }
+
+    @Test
+    fun `delivered の後に processed が届いても壊れない`() {
+        // 作業順序 8 の本題。SendGrid のイベントは順序が乱れる
+        val inOrder = AddressState.from(listOf(event("processed", occurredAt = BASE), event("delivered", occurredAt = BASE + 60)))
+        val reversed = AddressState.from(listOf(event("delivered", occurredAt = BASE + 60), event("processed", occurredAt = BASE)))
+
+        assertTrue(inOrder.sendable)
+        assertEquals(inOrder, reversed)
+    }
+
+    @Test
+    fun `bounce の後に delivered が届いても sendable は戻らない`() {
+        // 単発のイベントを順に適用していたら、ここで true に戻る
+        val state =
+            AddressState.from(
+                listOf(
+                    event("bounce", bounceType = "bounce", occurredAt = BASE),
+                    event("delivered", occurredAt = BASE + 60),
+                ),
+            )
+
+        assertFalse(state.sendable)
+        assertEquals("hard_bounce", state.reasonCode)
+    }
+
+    @Test
+    fun `同じイベントを二度読んでも状態は変わらない`() {
+        // 窓が重なる以上、同じイベントは何度も読まれる（docs/SPEC.md §4.4）
+        val once = AddressState.from(listOf(event("spamreport")))
+        val twice = AddressState.from(listOf(event("spamreport"), event("spamreport")))
+
+        assertEquals(once, twice)
+    }
+
+    @Test
+    fun `deferred は sendable を落とさず、soft_bounce_count を増やす`() {
+        // 一時的な失敗である。恒久的な不達と混ぜない
+        val state = AddressState.from(listOf(event("deferred", occurredAt = BASE), event("deferred", occurredAt = BASE + 60)))
+
+        assertTrue(state.sendable)
+        assertNull(state.reasonCode)
+        assertEquals(2, state.softBounceCount)
+        assertEquals(Instant.ofEpochSecond(BASE + 60), state.lastFailureAt?.toInstant())
+    }
+
+    @Test
+    fun `blocked は sendable を落とさず、soft_bounce_count を増やす`() {
+        // event は bounce だが type が blocked。受け取り側が一時的に拒んだだけである
+        val state = AddressState.from(listOf(event("bounce", bounceType = "blocked")))
+
+        assertTrue(state.sendable)
+        assertNull(state.reasonCode)
+        assertEquals(1, state.softBounceCount)
+    }
+
+    @Test
+    fun `type が無い bounce は恒久扱いにする`() {
+        // 分類できないものを一時扱いにすると、届かないアドレスへ送り続ける
+        val state = AddressState.from(listOf(event("bounce", bounceType = null)))
+
+        assertFalse(state.sendable)
+        assertEquals("hard_bounce", state.reasonCode)
+        assertEquals(0, state.softBounceCount)
+    }
+
+    @Test
+    fun `dropped だけなら reason_code は付かない`() {
+        // 送れないことは分かるが、理由は他のイベントが持つ。
+        // reason の文字列を読んで振り分けない（SendGrid が文言を変えた日に壊れる）
+        val state = AddressState.from(listOf(event("dropped", occurredAt = BASE)))
+
+        assertFalse(state.sendable)
+        assertNull(state.reasonCode)
+        assertEquals(Instant.ofEpochSecond(BASE), state.lastFailureAt?.toInstant())
+    }
+
+    @Test
+    fun `group_unsubscribe と group_resubscribe は状態を変えない`() {
+        // グループ単位の購読可否は SendGrid 側が持つ。粒度が違う（AddressState.from の KDoc）
+        val state =
+            AddressState.from(
+                listOf(
+                    event("delivered"),
+                    event("group_unsubscribe"),
+                    event("group_resubscribe"),
+                ),
+            )
+
+        assertTrue(state.sendable)
+        assertNull(state.reasonCode)
+        assertNull(state.lastFailureAt)
+    }
+
+    @Test
+    fun `open と click は状態を変えない`() {
+        val state = AddressState.from(listOf(event("delivered"), event("open"), event("click")))
+
+        assertEquals(AddressState.from(listOf(event("delivered"))), state)
+    }
+
+    @Test
+    fun `account_status_change は状態を変えない`() {
+        // 送信者アカウントの状態であって、宛先アドレスの話ではない
+        val state = AddressState.from(listOf(event("delivered"), event("account_status_change")))
+
+        assertTrue(state.sendable)
+        assertNull(state.reasonCode)
+    }
+
+    @Test
+    fun `優先度は spamreport が最も強い`() {
+        val state =
+            AddressState.from(
+                listOf(
+                    event("dropped"),
+                    event("unsubscribe"),
+                    event("bounce", bounceType = "bounce"),
+                    event("spamreport"),
+                ).shuffled(),
+            )
+
+        assertEquals("spam_report", state.reasonCode)
+    }
+
+    @Test
+    fun `優先度は hard_bounce が unsubscribe より強い`() {
+        val state =
+            AddressState.from(
+                listOf(event("unsubscribe"), event("bounce", bounceType = "bounce"), event("dropped")).shuffled(),
+            )
+
+        assertEquals("hard_bounce", state.reasonCode)
+    }
+
+    @Test
+    fun `優先度は unsubscribe が dropped より強い`() {
+        // dropped は「抑制リストに載っていたので捨てた」という結果で、unsubscribe はその原因である
+        val state = AddressState.from(listOf(event("dropped"), event("unsubscribe")).shuffled())
+
+        assertEquals("unsubscribe", state.reasonCode)
+    }
+
+    @Test
+    fun `unsubscribe では last_failure_at が動かない`() {
+        // 購読解除は失敗ではない。列名が意味するものを守る
+        val state = AddressState.from(listOf(event("unsubscribe")))
+
+        assertNull(state.lastFailureAt)
+    }
+
+    @Test
+    fun `last_failure_at は失敗イベントの最新を採る`() {
+        val state =
+            AddressState.from(
+                listOf(
+                    event("bounce", bounceType = "bounce", occurredAt = BASE),
+                    event("deferred", occurredAt = BASE + 600),
+                    // 失敗ではないので、これが最新でも last_failure_at にはならない
+                    event("delivered", occurredAt = BASE + 1200),
+                ),
+            )
+
+        assertEquals(Instant.ofEpochSecond(BASE + 600), state.lastFailureAt?.toInstant())
+    }
+
+    @Test
+    fun `イベントが 1 件も無ければ送ってよい`() {
+        val state = AddressState.from(emptyList())
+
+        assertTrue(state.sendable)
+        assertNull(state.reasonCode)
+        assertNull(state.lastFailureAt)
+        assertEquals(0, state.softBounceCount)
+    }
+
+    private companion object {
+        const val BASE = 1798723200L
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/event/EmailMaskTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/event/EmailMaskTest.kt
@@ -1,0 +1,40 @@
+package io.propagandist.recibir.event
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * ログへ出すアドレスの伏せ方（`docs/SPEC.md` §4.7 / #5）。
+ *
+ * **DB も Spring も要らない。** 実際に出た 1 行の中身は `EventProjectorTest` が見る。
+ */
+class EmailMaskTest {
+    @Test
+    fun `ローカル部を伏せ、ドメインは残す`() {
+        // ドメインを残すのは、特定ドメインへの集中的な配信不能をログだけで読むためである
+        assertEquals("***@example.com", maskEmail("user@example.com"))
+    }
+
+    @Test
+    fun `1 文字のローカル部も全部伏せる`() {
+        // 先頭 1 文字を残す形だと、ここでローカル部がそのまま全部出る
+        assertEquals("***@example.com", maskEmail("a@example.com"))
+    }
+
+    @Test
+    fun `アットマークが無ければ全部伏せる`() {
+        // email 列に何が入るかを決めているのは SendGrid であって、こちらではない
+        assertEquals("***", maskEmail("not-an-address"))
+    }
+
+    @Test
+    fun `空文字も全部伏せる`() {
+        assertEquals("***", maskEmail(""))
+    }
+
+    @Test
+    fun `アットマークが複数あれば最後で分ける`() {
+        // ローカル部に @ を含む形（引用符で囲んだもの）が来ても、残るのはドメインだけになる
+        assertEquals("***@example.com", maskEmail("a@b@example.com"))
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/event/EventProjectorTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/event/EventProjectorTest.kt
@@ -1,0 +1,260 @@
+package io.propagandist.recibir.event
+
+import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
+import io.propagandist.jooq.Tables.SENDGRID_EVENT
+import io.propagandist.recibir.support.PostgresContainer
+import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.structuredLogs
+import org.jooq.DSLContext
+import org.jooq.JSONB
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * 窓・書き込み・ログを、実際の DB で確かめる。
+ *
+ * 状態決定そのものは `AddressStateTest` が見る（あちらは DB が要らない）。
+ * ここが見るのは**どれを・いつ作り直すか**と、**送れなくなったことに気づけるか**である。
+ *
+ * **既定では窓の外へ置く。** コンテキストにはスケジューラが居て（`config/SchedulingConfig`）、
+ * テストの最中にも窓を拾いに来る。窓の外に置いてあれば割り込まれても結果が変わらない
+ * ——窓を見るテストだけが窓の中を使い、**そちらは何度作り直しても同じ状態になる。**
+ *
+ * DB は Testcontainers が立てる。**Docker が要る。**
+ */
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension::class)
+class EventProjectorTest {
+    @Autowired
+    private lateinit var projector: EventProjector
+
+    @Autowired
+    private lateinit var dsl: DSLContext
+
+    private var seq = 0
+
+    @BeforeEach
+    fun clean() {
+        dsl.deleteFrom(SENDGRID_EVENT).execute()
+        dsl.deleteFrom(EMAIL_ADDRESS_STATE).execute()
+    }
+
+    /**
+     * イベントを 1 件、直接入れる。
+     *
+     * **投入サービスを通していない。** `received_at` を明示したいためで、あちらは
+     * DB の `DEFAULT now()` に任せる（`docs/SPEC.md` §3.1）。窓の内と外を書き分けられない。
+     */
+    private fun insert(
+        email: String,
+        event: String,
+        bounceType: String? = null,
+        receivedAt: OffsetDateTime = OUTSIDE_WINDOW,
+        occurredAt: Long = BASE,
+    ) {
+        dsl
+            .insertInto(SENDGRID_EVENT)
+            .set(SENDGRID_EVENT.SG_EVENT_ID, "e${seq++}")
+            .set(SENDGRID_EVENT.EMAIL, email)
+            .set(SENDGRID_EVENT.EVENT, event)
+            .set(SENDGRID_EVENT.BOUNCE_TYPE, bounceType)
+            .set(SENDGRID_EVENT.OCCURRED_AT, Instant.ofEpochSecond(occurredAt).atOffset(ZoneOffset.UTC))
+            .set(SENDGRID_EVENT.RECEIVED_AT, receivedAt)
+            .set(SENDGRID_EVENT.PAYLOAD, JSONB.valueOf("{}"))
+            .execute()
+    }
+
+    private fun state(email: String) = dsl.fetchOne(EMAIL_ADDRESS_STATE, EMAIL_ADDRESS_STATE.EMAIL.eq(email))
+
+    /** `updated_at` を除いた中身。作り直しのたびに動きうる列なので、同一性の比較からは外す。 */
+    private fun snapshot(email: String) =
+        state(email)!!.let {
+            listOf(it.sendable, it.reasonCode, it.lastFailureAt?.toInstant(), it.softBounceCount)
+        }
+
+    @Test
+    fun `窓に入ったアドレスだけが作り直される`() {
+        insert("inside@example.com", "delivered", receivedAt = INSIDE_WINDOW)
+        insert("outside@example.com", "delivered", receivedAt = OUTSIDE_WINDOW)
+
+        projector.projectRecent()
+
+        assertNotNull(state("inside@example.com"))
+        assertNull(state("outside@example.com"))
+    }
+
+    @Test
+    fun `窓の外のイベントも、同じアドレスの状態には含まれる`() {
+        // 窓が決めるのは「どのアドレスを作り直すか」だけで、
+        // 状態はそのアドレスの全イベントから決まる（docs/SPEC.md §4.4）
+        insert("user@example.com", "bounce", bounceType = "bounce", receivedAt = OUTSIDE_WINDOW, occurredAt = BASE)
+        insert("user@example.com", "delivered", receivedAt = INSIDE_WINDOW, occurredAt = BASE + 60)
+
+        projector.projectRecent()
+
+        val row = state("user@example.com")!!
+        assertFalse(row.sendable)
+        assertEquals("hard_bounce", row.reasonCode)
+    }
+
+    @Test
+    fun `遅れて届いたイベントも窓に入る`() {
+        // received_at で絞るのはこのため。occurred_at で絞ると、
+        // SendGrid 側の時刻が古いイベントは届いた日にもう窓から外れている
+        insert("user@example.com", "bounce", bounceType = "bounce", receivedAt = INSIDE_WINDOW, occurredAt = BASE - 86400)
+
+        projector.projectRecent()
+
+        assertFalse(state("user@example.com")!!.sendable)
+    }
+
+    @Test
+    fun `変わっていなければ updated_at は動かない`() {
+        insert("user@example.com", "delivered")
+        projector.project("user@example.com")
+        val first = state("user@example.com")!!.updatedAt
+
+        projector.project("user@example.com")
+
+        // 窓が重なる以上、同じアドレスは何度も通る。毎回書くと
+        // 「いつ状態が変わったか」が読めなくなる
+        assertEquals(first.toInstant(), state("user@example.com")!!.updatedAt.toInstant())
+    }
+
+    @Test
+    fun `新しいイベントが増えれば書き直される`() {
+        insert("user@example.com", "delivered")
+        projector.project("user@example.com")
+
+        insert("user@example.com", "spamreport")
+        projector.project("user@example.com")
+
+        val row = state("user@example.com")!!
+        assertFalse(row.sendable)
+        assertEquals("spam_report", row.reasonCode)
+    }
+
+    @Test
+    fun `email_address_state を全削除してから rebuildAll すると同じ状態に戻る`() {
+        // 二次テーブルは捨てて作り直せる（docs/er.md「正本は sendgrid_event」）
+        insert("hard@example.com", "bounce", bounceType = "bounce")
+        insert("soft@example.com", "deferred", occurredAt = BASE)
+        insert("soft@example.com", "delivered", occurredAt = BASE + 60)
+        insert("gone@example.com", "unsubscribe")
+        val addresses = listOf("hard@example.com", "soft@example.com", "gone@example.com")
+        projector.rebuildAll()
+        val before = addresses.map { snapshot(it) }
+
+        dsl.deleteFrom(EMAIL_ADDRESS_STATE).execute()
+        projector.rebuildAll()
+
+        assertEquals(before, addresses.map { snapshot(it) })
+    }
+
+    @Test
+    fun `rebuildAll は窓の外のアドレスも作り直す`() {
+        insert("old@example.com", "bounce", bounceType = "bounce", receivedAt = OUTSIDE_WINDOW)
+
+        projector.rebuildAll()
+
+        assertFalse(state("old@example.com")!!.sendable)
+    }
+
+    @Test
+    fun `イベントが 1 件も無い状態行は rebuildAll で触られない`() {
+        // SuppressionReconciler が Suppression API を正として先に立てた行
+        // （docs/er.md の多重度 3 行目）。ここが消すと、取りこぼしの跡が毎回消える
+        dsl
+            .insertInto(EMAIL_ADDRESS_STATE)
+            .set(EMAIL_ADDRESS_STATE.EMAIL, "invalid@example.com")
+            .set(EMAIL_ADDRESS_STATE.SENDABLE, false)
+            .set(EMAIL_ADDRESS_STATE.REASON_CODE, "invalid")
+            .set(EMAIL_ADDRESS_STATE.UPDATED_AT, OffsetDateTime.now())
+            .execute()
+        insert("user@example.com", "delivered")
+
+        projector.rebuildAll()
+
+        assertEquals("invalid", state("invalid@example.com")!!.reasonCode)
+    }
+
+    @Test
+    fun `送れなくなると address_unsendable がマスク済みで出る`(output: CapturedOutput) {
+        insert("user@example.com", "bounce", bounceType = "bounce")
+
+        projector.project("user@example.com")
+
+        val entry = structuredLogs(output, "address.unsendable").single()
+        assertEquals("***@example.com", entry["email"].stringValue())
+        assertEquals("hard_bounce", entry["reason_code"].stringValue())
+        assertEquals("WARNING", entry["severity"].stringValue())
+        assertFalse(entry.toString().contains("user@"), entry.toString())
+    }
+
+    @Test
+    fun `変わっていなければ address_unsendable は出ない`(output: CapturedOutput) {
+        // 窓は重なる。毎分同じ行が出ると、監視の側で数を読めなくなる
+        insert("user@example.com", "spamreport")
+
+        projector.project("user@example.com")
+        projector.project("user@example.com")
+
+        assertEquals(1, structuredLogs(output, "address.unsendable").size)
+    }
+
+    @Test
+    fun `送れるアドレスでは address_unsendable が出ない`(output: CapturedOutput) {
+        insert("user@example.com", "deferred")
+
+        projector.project("user@example.com")
+
+        assertTrue(structuredLogs(output, "address.unsendable").isEmpty())
+        // 一時的な失敗なので、状態は残るが送れるままである
+        assertTrue(state("user@example.com")!!.sendable)
+    }
+
+    @Test
+    fun `dropped だけのアドレスでも address_unsendable は出る`(output: CapturedOutput) {
+        // reason_code は付かないが、送れなくなったことは伝える必要がある
+        insert("user@example.com", "dropped")
+
+        projector.project("user@example.com")
+
+        val entry = structuredLogs(output, "address.unsendable").single()
+        assertTrue(entry["reason_code"].isNull, entry.toString())
+    }
+
+    companion object {
+        private const val BASE = 1798723200L
+
+        /** 窓（10 分）の中。**スケジューラが同じことをしても結果は変わらない。** */
+        private val INSIDE_WINDOW: OffsetDateTime = OffsetDateTime.now()
+
+        /** 窓の外。ここに置いたものは、テストが自分で呼ぶまで作り直されない。 */
+        private val OUTSIDE_WINDOW: OffsetDateTime = OffsetDateTime.now().minusHours(1)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            PostgresContainer.register(registry)
+            // 射影は署名を見ないが、コンテキストを起動するには鍵が要る
+            // （SendGridWebhookConfiguration。既定値を置いていない）
+            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(TestKeyPair.generate()) }
+        }
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/event/RebuildAllRunnerTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/event/RebuildAllRunnerTest.kt
@@ -1,0 +1,81 @@
+package io.propagandist.recibir.event
+
+import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
+import io.propagandist.jooq.Tables.SENDGRID_EVENT
+import io.propagandist.recibir.support.PostgresContainer
+import io.propagandist.recibir.support.TestKeyPair
+import org.jooq.DSLContext
+import org.jooq.JSONB
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.DefaultApplicationArguments
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * 起動引数で全件再構築が起きること、**引数が無ければ起きないこと**を確かめる。
+ *
+ * イベントは窓の外へ置く。スケジューラが拾ってしまうと、
+ * 引数を見ずに作り直したのか区別できなくなる（`EventProjectorTest` と同じ理由）。
+ *
+ * DB は Testcontainers が立てる。**Docker が要る。**
+ */
+@SpringBootTest
+class RebuildAllRunnerTest {
+    @Autowired
+    private lateinit var runner: RebuildAllRunner
+
+    @Autowired
+    private lateinit var dsl: DSLContext
+
+    @BeforeEach
+    fun clean() {
+        dsl.deleteFrom(SENDGRID_EVENT).execute()
+        dsl.deleteFrom(EMAIL_ADDRESS_STATE).execute()
+        dsl
+            .insertInto(SENDGRID_EVENT)
+            .set(SENDGRID_EVENT.SG_EVENT_ID, "rebuild-1")
+            .set(SENDGRID_EVENT.EMAIL, EMAIL)
+            .set(SENDGRID_EVENT.EVENT, "bounce")
+            .set(SENDGRID_EVENT.BOUNCE_TYPE, "bounce")
+            .set(SENDGRID_EVENT.OCCURRED_AT, Instant.ofEpochSecond(1798723200).atOffset(ZoneOffset.UTC))
+            .set(SENDGRID_EVENT.RECEIVED_AT, OffsetDateTime.now().minusHours(1))
+            .set(SENDGRID_EVENT.PAYLOAD, JSONB.valueOf("{}"))
+            .execute()
+    }
+
+    private fun state() = dsl.fetchOne(EMAIL_ADDRESS_STATE, EMAIL_ADDRESS_STATE.EMAIL.eq(EMAIL))
+
+    @Test
+    fun `引数が付いていれば全件を作り直す`() {
+        runner.run(DefaultApplicationArguments("--rebuild-all"))
+
+        assertNotNull(state())
+    }
+
+    @Test
+    fun `引数が無ければ何もしない`() {
+        // 起動のたびに全件を作り直すと、規模が大きくなった日に起動が止まる
+        runner.run(DefaultApplicationArguments())
+
+        assertNull(state())
+    }
+
+    companion object {
+        private const val EMAIL = "user@example.com"
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            PostgresContainer.register(registry)
+            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(TestKeyPair.generate()) }
+        }
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/support/StructuredLogs.kt
+++ b/src/test/kotlin/io/propagandist/recibir/support/StructuredLogs.kt
@@ -1,0 +1,34 @@
+package io.propagandist.recibir.support
+
+import org.springframework.boot.test.system.CapturedOutput
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * 出た構造化ログのうち、`event` が一致する行を**出た順に**取り出す。
+ *
+ * **stdout をそのまま読む。** 形式の定義は `config/CloudLoggingFormat` にあるが、
+ * テストが見るのは**実際に出た 1 行**である——運用が読むのもこれになる。
+ *
+ * 受信経路（`webhook`）と射影（`event`）の 2 か所からログを見るようになった時点で、
+ * `WebhookLoggingTest` からここへ出した。
+ */
+fun structuredLogs(
+    output: CapturedOutput,
+    event: String,
+): List<JsonNode> =
+    output.all
+        .lineSequence()
+        .filter { it.startsWith("{") }
+        .map { mapper.readTree(it) }
+        .filter { it["event"]?.stringValue() == event }
+        .toList()
+
+/**
+ * 読むためだけのマッパー。
+ *
+ * **アプリの `JsonMapper` を注入していない。** ここが要るのは「出た 1 行を JSON として
+ * 読み直す」ことだけで、アプリ側の設定に揃える理由が無い。揃えると、
+ * **アプリの設定を変えた日にテストの読み方が黙って変わる。**
+ */
+private val mapper = JsonMapper.builder().build()

--- a/src/test/kotlin/io/propagandist/recibir/webhook/WebhookLoggingTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/WebhookLoggingTest.kt
@@ -3,6 +3,7 @@ package io.propagandist.recibir.webhook
 import io.propagandist.jooq.Tables.SENDGRID_EVENT
 import io.propagandist.recibir.support.PostgresContainer
 import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.structuredLogs
 import org.jooq.DSLContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,8 +18,6 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
-import tools.jackson.databind.JsonNode
-import tools.jackson.databind.json.JsonMapper
 import java.security.KeyPair
 import java.time.Instant
 import kotlin.test.assertEquals
@@ -45,25 +44,10 @@ class WebhookLoggingTest {
     @Autowired
     private lateinit var dsl: DSLContext
 
-    @Autowired
-    private lateinit var jsonMapper: JsonMapper
-
     @BeforeEach
     fun clean() {
         dsl.deleteFrom(SENDGRID_EVENT).execute()
     }
-
-    /** `event` が一致する行だけを、出た順に取り出す。 */
-    private fun entries(
-        output: CapturedOutput,
-        event: String,
-    ): List<JsonNode> =
-        output.all
-            .lineSequence()
-            .filter { it.startsWith("{") }
-            .map { jsonMapper.readTree(it) }
-            .filter { it["event"]?.stringValue() == event }
-            .toList()
 
     private fun send(
         payload: String,
@@ -81,7 +65,7 @@ class WebhookLoggingTest {
         // 受信の途絶は、この行が来なくなることで捕まえる（#5）
         send(DELIVERED).andExpect { status { isOk() } }
 
-        assertEquals(1, entries(output, "webhook.received").size)
+        assertEquals(1, structuredLogs(output, "webhook.received").size)
     }
 
     @Test
@@ -92,10 +76,10 @@ class WebhookLoggingTest {
             content { string("") }
         }
 
-        val rejected = entries(output, "webhook.rejected").single()
+        val rejected = structuredLogs(output, "webhook.rejected").single()
         assertEquals("signature_mismatch", rejected["reason"].stringValue())
         // 受信そのものが成立していないので、この行は出ない
-        assertTrue(entries(output, "webhook.received").isEmpty())
+        assertTrue(structuredLogs(output, "webhook.received").isEmpty())
     }
 
     @Test
@@ -103,7 +87,7 @@ class WebhookLoggingTest {
         // 検証を通っていない入力は信頼できない。ログへ流すと、そこが汚れる経路になる
         send(DELIVERED, body = "${DELIVERED}X").andExpect { status { isForbidden() } }
 
-        val rejected = entries(output, "webhook.rejected").single().toString()
+        val rejected = structuredLogs(output, "webhook.rejected").single().toString()
         assertFalse(rejected.contains("user@example.com"), rejected)
         assertFalse(rejected.contains("sg_event_id"), rejected)
     }
@@ -117,7 +101,7 @@ class WebhookLoggingTest {
                 content = DELIVERED.toByteArray()
             }.andExpect { status { isForbidden() } }
 
-        assertEquals("missing_header", entries(output, "webhook.rejected").single()["reason"].stringValue())
+        assertEquals("missing_header", structuredLogs(output, "webhook.rejected").single()["reason"].stringValue())
     }
 
     @Test
@@ -129,7 +113,7 @@ class WebhookLoggingTest {
 
         assertEquals(
             "timestamp_out_of_range",
-            entries(output, "webhook.rejected").single()["reason"].stringValue(),
+            structuredLogs(output, "webhook.rejected").single()["reason"].stringValue(),
         )
     }
 
@@ -139,7 +123,7 @@ class WebhookLoggingTest {
         send(DELIVERED).andExpect { status { isOk() } }
         send(DELIVERED).andExpect { status { isOk() } }
 
-        val ingested = entries(output, "event.ingested")
+        val ingested = structuredLogs(output, "event.ingested")
         assertEquals(2, ingested.size)
         assertEquals(1, ingested[0]["received"].intValue())
         assertEquals(1, ingested[0]["inserted"].intValue())
@@ -158,7 +142,7 @@ class WebhookLoggingTest {
             """.trimIndent(),
         ).andExpect { status { isOk() } }
 
-        val byType = entries(output, "event.ingested").single()["by_type"]
+        val byType = structuredLogs(output, "event.ingested").single()["by_type"]
         assertEquals(1, byType["delivered"].intValue())
         assertEquals(1, byType["bounce"].intValue())
     }
@@ -169,15 +153,15 @@ class WebhookLoggingTest {
         // （README「200 と 500 の切り分け」）。気づく手段はこの 1 行だけである
         send("""[{"sg_event_id":"a",""").andExpect { status { isOk() } }
 
-        assertEquals(1, entries(output, "event.unparseable").size)
-        assertTrue(entries(output, "event.ingested").isEmpty())
+        assertEquals(1, structuredLogs(output, "event.unparseable").size)
+        assertTrue(structuredLogs(output, "event.ingested").isEmpty())
     }
 
     @Test
     fun `解釈できないボディの中身はログに出ない`(output: CapturedOutput) {
         send("""[{"sg_event_id":"a","email":"user@example.com",""").andExpect { status { isOk() } }
 
-        val unparseable = entries(output, "event.unparseable").single().toString()
+        val unparseable = structuredLogs(output, "event.unparseable").single().toString()
         assertFalse(unparseable.contains("user@example.com"), unparseable)
     }
 
@@ -185,7 +169,7 @@ class WebhookLoggingTest {
     fun `ログの各行は severity と message を持つ`(output: CapturedOutput) {
         send(DELIVERED).andExpect { status { isOk() } }
 
-        val received = entries(output, "webhook.received").single()
+        val received = structuredLogs(output, "webhook.received").single()
         assertEquals("INFO", received["severity"].stringValue())
         assertTrue(received["message"].stringValue().isNotEmpty())
         assertNull(received["stack_trace"])


### PR DESCRIPTION
`sendgrid_event` から `email_address_state` を組み上げる層を入れる（#36。`docs/HANDOVER.md` の作業順序 8）。
これまで `sendgrid_event` は溜まる一方で、**読む側が居なかった**。
#5 の残りのうち `address.unsendable` とアドレスのマスクも、この層に入っている。

**マージ方式の都合で、コミットの本文は既定ブランチの履歴に残らない**（org `work-conventions.md` §5）。
判断はここへまとめる。

## 判断とその理由

### 処理済みを追わず、直近の窓で拾う

間隔 1 分、窓は `received_at` で 10 分。状態は対象アドレスの全イベントから決まるので、
**同じアドレスを何度作り直しても結果は同じ**になる。だから「未処理」を厳密に追う必要が無い。
窓が間隔より長いのは無駄ではなく、**1 回失敗しても次の回で拾える**という意味を持つ。
長く止まった後の取りこぼしは `--rebuild-all` が受け皿になる。

**`received_at` で絞っている。** `occurred_at` で絞ると、遅れて届いたイベントは
届いた日にはもう窓の外にあり、永久に拾えない。

### 状態決定を、DB も Spring も見ない関数に置いた

`event/AddressState.kt` が見るのは「その種類が 1 件でもあるか」だけで、
**並び順にも件数にも依存しない**。`delivered` の後に `processed` が届いても、
同じイベントを二度読んでも、結果は変わらない。読む側が `ORDER BY` を書かずに済む。

### 優先度に `unsubscribe` を足し、`docs/SPEC.md` §4.4 を変えた

直近の 2 本（#32 / #34）は「SPEC を変更しない」で通したが、ここは設計の穴だった
——§3.2 が要求する `reason_code` のうち `unsubscribe` を、§4.4 の手順では作れない。

`dropped` より前に置いた。`dropped` は「抑制リストに載っていたので捨てた」という**結果**で、
`unsubscribe` はその**原因**である。

### 恒久的な不達を「`blocked` でない `bounce`」で判定した

§4.4 の字面どおり `type == "bounce"` と書くと、**`type` が落ちた日に恒久的な不達を
一時扱いにする**。分類できないものは送らない側へ倒す。

### 変わっていなければ書かない

窓が重なる以上、同じアドレスは何度も通る。毎回書くと `updated_at` が 1 分ごとに動いて
「いつ状態が変わったか」が読めなくなり、`address.unsendable` も毎分出て
監視の側で数を読めなくなる。

### `--rebuild-all` の後もそのまま起動を続ける

終了させる形にすると、起動コマンドへ引数が残った日にアプリが二度と上がらない。
続ければ、残っていても起動が少し遅くなるだけで済む。

## #36 の本文から逸脱した 2 点

### `V2__index_received_at.sql` を足した

対象範囲にマイグレーションは無かった。ただし索引が無いと「1 分ごとに数件を読む」形にならない
——窓に入るのが数件でも、`received_at` に索引が無ければ毎分すべての行を走ることになり、
`sendgrid_event` は append-only なので走る量だけが増え続ける。

V1 は書き換えていない。手元の DB には既に V1 が当たっており、
書き換えるとチェックサムが合わずに `flywayMigrate` が落ちる。

### `docs/SPEC.md` §4.7 のマスクの例を直した

`u***@example.com` のまま実装すると、**1 文字のローカル部がそのまま全部出る**。
#5 の受け入れ基準がこの観点を名指ししているので、実装を「1 文字も残さない」側へ倒し、
例を `***@example.com` へ直した。ドメインだけ残せば、§4.7 が挙げた目的
（特定ドメインへの集中的な配信不能をログだけで読む）は満たせる。

## 却下した案

| 案 | 却下理由 |
|---|---|
| 処理済みの id を記録するテーブルを足す | 捨てて作り直せない三つ目のテーブルが増える |
| `sendgrid_event` に処理済みの列を足す | 正本を append-only に保てなくなる（§3.1） |
| 窓と間隔を設定項目にする | §5。署名検証の許容ずれと同じ扱いにした |
| 状態決定をイベントの時系列に順に適用する | 単発遷移になり、順序の乱れで壊れる |
| `dropped` の `reason` 文字列で `reason_code` を決める | SendGrid が文言を変えた日に黙って壊れる |
| `group_unsubscribe` で `sendable` を落とす | 粒度が違う。送れるはずのメールが送れなくなる |
| 全件再構築を HTTP エンドポイントにする | 管理 UI に近づく（§2 の「含まない」） |
| 射影に `@Transactional` を張る | 読みと書きの間に入ったイベントは次のポーリングが拾う。窓を重ねた理由と二重になる |

## 確かめ方

`./gradlew build` が **104 件 green**（2026-08-29 実測。**Docker が要る**）。
新しく足したのは `AddressStateTest` 19 件 ／ `EventProjectorTest` 12 件 ／
`EmailMaskTest` 5 件 ／ `RebuildAllRunnerTest` 2 件。

`--rebuild-all` は手元で実走した（同日）。`bounce` の後に `delivered` が届いたアドレス、
`dropped` だけのアドレス、`deferred` だけのアドレスの 3 件を入れて起動し、次を確認した。

- `address.unsendable` が 2 件出て、どちらも `***@example.com` の形だった
- `bounce` の後に `delivered` が来ても `sendable` は戻らず、`reason_code` は `hard_bounce` だった
- `dropped` だけのアドレスの `reason_code` は `null` で出た
- `deferred` だけのアドレスは `sendable = true` のまま `soft_bounce_count` が 1 になった
- 作り直した後もそのまま起動を続けた

org の `writing-baseline.md` §8 の検査も手元で回した（同日）。追加分で「〜ない。」が
3 連続になった箇所を 1 つ言い換え、「ということ」を 1 件消してある。
残る 3 連続 1 箇所と一文長（n=91 中央値 32 ／ p90 48 ／ 最大 63 ／ 60 字超 1 件）は
変更前と同じ値である。

## 残るもの

- **#5 は閉じない。** `reconcile.drift` が作業順序 9 に残っている
- `SuppressionReconciler` が付けた `reason_code` を射影が上書きしてよいかは、
  `docs/HANDOVER.md` の未決事項へ置いた。決まるのは作業順序 9 の側である

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
