### PR TITLE
feat: Suppression API と突き合わせ、Webhook の取りこぼしを量として出す

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,16 +149,20 @@ docker compose up -d          # PostgreSQL
 ./gradlew flywayMigrate       # スキーマ適用（jOOQ codegen の前提）
 ./gradlew jooqCodegen         # jOOQ コード生成。通っていないと永続化層はコンパイルできない
 ./gradlew build
-SENDGRID_WEBHOOK_PUBLIC_KEY=<SendGrid が配る公開鍵> ./gradlew bootRun
+SENDGRID_WEBHOOK_PUBLIC_KEY=<SendGrid が配る公開鍵> \
+  SENDGRID_API_KEY=<Suppression API を読める API キー> \
+  ./gradlew bootRun
 ```
 
 SendGrid は公開 URL にしか POST しないため、ローカル開発では
 ngrok / Cloudflare Tunnel などでトンネルを張ってください。
 
-受信に必要な設定は `sendgrid.webhook.public-key` のみです。
-SendGrid 管理画面の `Settings > Mail Settings > Signed Event Webhook Requests`
-で署名検証を有効化すると表示されます。
-Suppression API との突き合わせも動かす場合は `sendgrid.api.key` が追加で要ります。
+設定は `sendgrid.webhook.public-key` と `sendgrid.api.key` の 2 つです。
+前者は SendGrid 管理画面の `Settings > Mail Settings > Signed Event Webhook Requests`
+で署名検証を有効化すると表示され、後者は Suppression API との突き合わせが使います。
+
+**受信だけを試す場合も、両方が要ります。** 片方で起動できるようにすると、
+突き合わせが動かないまま「動いているつもり」になれてしまいます。
 
 **既定値は置いていないので、鍵を渡さないと起動しません。** 空で起動できるようにすると、
 設定を忘れたまま全イベントを 403 で弾き続けることになり、それは「解こうとしている問題」が挙げた

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -138,12 +138,6 @@ Kotlin の data class では use-site target を明示しないと
 ## 未決事項
 
 - [ ] ライセンスヘッダを全ファイルに入れるか、`NOTICE` に集約するか
-- [ ] `SuppressionReconciler` の実行時刻
-- [ ] `SuppressionReconciler` が付けた `reason_code` を、`EventProjector` が上書きしてよいか。
-      **イベントが 1 件も無い状態行は触らない**（射影は `sendgrid_event` に出てくる
-      アドレスだけを回す）。ただし**イベントもある**アドレスに `invalid` が付いていた場合は、
-      次の射影で消える。`docs/SPEC.md` §4.5 は「SendGrid 側を正とする」と書いており、
-      **どちらを採るかは作業順序 9 で決まる**
 
 ## やらないこと（再確認）
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -137,15 +137,31 @@ ECDSA（`SHA256withECDSA`、EC P-256）による署名検証。
 
 ### 4.5 `SuppressionReconciler`（`reconcile/`）
 
-日次バッチ。以下を取得し `email_address_state` と突き合わせる。
+日次バッチ（03:00 UTC）。以下を**全件**取得し `email_address_state` と突き合わせる。
+**期間で絞らない**——取りこぼしは絞った窓の外に落ちたまま、永久に見つからない。
 
-- `GET /v3/suppression/bounces`
-- `GET /v3/suppression/blocks`
-- `GET /v3/suppression/invalid_emails`
-- `GET /v3/suppression/spam_reports`
+| エンドポイント | 差分と数えるもの | 補完 |
+|---|---|---|
+| `GET /v3/suppression/spam_reports` | 行が無い、または `sendable = true` | `spam_report` |
+| `GET /v3/suppression/bounces` | 同上 | `hard_bounce` |
+| `GET /v3/suppression/invalid_emails` | 同上 | `invalid` |
+| `GET /v3/suppression/blocks` | **行が無いものだけ** | **書き換えない** |
 
-差分が出た場合は Webhook の取りこぼしを意味するため、警告ログを出す。
-SendGrid 側を正とする。
+上から順に見て、先に当たった `reason_code` が残る（§4.4 の優先度に合わせてある）。
+
+差分が出た場合は Webhook の取りこぼしを意味するため、警告ログを出す
+（§4.7 の `reconcile.drift`）。**差分が 0 のときは出さない**——毎日出続けると、
+監視の側に無視する習慣ができる。
+
+**SendGrid 側を正とする。ただし落とす方向だけである。** SendGrid 側に無いものを
+こちらから消さない——抑制リストは運用者が手で外すことがあり、それを
+「送ってよくなった」と読むと、**外した瞬間に過去のバウンス先へ送り始める。**
+
+**`blocks` は状態を書き換えない。** §4.4 が `blocked` で `sendable` を落とさないのと
+同じ理由で、**一時的な失敗だから**である。落とすと、SendGrid 側が外した日に戻せない。
+
+`last_failure_at` と `soft_bounce_count` にも触らない。どちらも Webhook 由来の値で、
+Suppression API の `created` は「リストに載った時刻」である。
 
 ### 4.6 セキュリティ設定（`config/`）
 

--- a/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionApiClient.kt
+++ b/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionApiClient.kt
@@ -1,0 +1,99 @@
+package io.propagandist.recibir.reconcile
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.web.client.RestClient
+
+/**
+ * Suppression API のリストを**全件**取る。
+ *
+ * **[SuppressionReconciler] と違って Spring に依存していない。**
+ * 組み立ては [SuppressionApiConfiguration] が持つ。受信側の
+ * [io.propagandist.recibir.webhook.SendGridSignatureVerifier] と同じ構えである
+ * ——**このリポジトリは読んで持っていかれることが目的**なので、外部 API を叩く部分は
+ * フレームワークから切り離しておく。
+ *
+ * ## 期間で絞らない
+ *
+ * `start_time` / `end_time` を使わない。**期間で絞ると、取りこぼしは窓の外に落ちたまま
+ * 永久に見つからない**——それは、まさに検出したいものである。
+ *
+ * **「前回いつ実行したか」も記録しない。** 記録すれば、捨てて作り直せない状態が増える
+ * （#34 で退避テーブルを、#36 で処理済みテーブルを却下したのと同じ理由）。
+ * 抑制リストは送信量ではなく**失敗した分だけ**溜まるので、全件でも数ページに収まる。
+ */
+class SuppressionApiClient(
+    private val restClient: RestClient,
+) {
+    /**
+     * 1 つのリストを全件取り、アドレスの集合にする。
+     *
+     * **`email` 以外を読まない。** 突き合わせに要るのはアドレスだけで、`reason` の文字列は
+     * 読まない（`docs/SPEC.md` §4.4 と同じ判断——SendGrid が文言を変えた日に壊れる）。
+     * `reason_code` は [SuppressionSource] が持ち、応答からは決めない。
+     *
+     * **`created` も読まない。** `email_address_state.last_failure_at` は Webhook 由来の
+     * 発生時刻で、こちらの `created` は**リストに載った時刻**である。埋めると列の意味が 2 つになる。
+     */
+    fun fetch(source: SuppressionSource): Set<String> {
+        val emails = mutableSetOf<String>()
+        var offset = 0
+        repeat(MAX_PAGES) {
+            val page = page(source, offset)
+            page.mapTo(emails) { it.email }
+            // 最後のページは満たない。ちょうど割り切れる場合は、次が空で返って終わる
+            if (page.size < PAGE_SIZE) return emails
+            offset += PAGE_SIZE
+        }
+        // **上限を置くのは、同じページが返り続けた日に日次バッチが終わらなくなるため**である。
+        // 打ち切った事実を残さないと、全件を見たのか途中で止めたのかが読めない
+        log.warn("stopped paging {} after {} pages", source.label, MAX_PAGES)
+        return emails
+    }
+
+    private fun page(
+        source: SuppressionSource,
+        offset: Int,
+    ): List<SuppressionEntry> =
+        restClient
+            .get()
+            .uri { builder ->
+                builder
+                    .path(source.path)
+                    .queryParam("limit", PAGE_SIZE)
+                    .queryParam("offset", offset)
+                    .build()
+            }.retrieve()
+            .body(ENTRY_LIST)
+            ?: emptyList()
+
+    internal companion object {
+        val log = LoggerFactory.getLogger(SuppressionApiClient::class.java)
+
+        /** 1 ページの件数。**API の上限が 500 である**（2026-08-29 に原文で確認）。 */
+        const val PAGE_SIZE = 500
+
+        /**
+         * 辿るページ数の上限。**500 × 200 で 10 万件**に当たる。
+         *
+         * 月数万通規模（`docs/SPEC.md` §4.4）の抑制リストは、これに遠く届かない。
+         * 置いてあるのは規模のためではなく、**終わらない日のため**である。
+         */
+        const val MAX_PAGES = 200
+
+        val ENTRY_LIST = object : ParameterizedTypeReference<List<SuppressionEntry>>() {}
+    }
+}
+
+/**
+ * 応答の 1 件。**アドレスだけを拾う。**
+ *
+ * 4 つのリストで形が違う（`spam_reports` だけ `reason` を持たず `ip` を持つ）。
+ * **共通する形へ寄せるより、要るものだけを取るほうが短い**——
+ * 寄せると、持っていないフィールドを全部 null 許容で抱えることになる。
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+internal data class SuppressionEntry(
+    val email: String,
+)

--- a/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionApiConfiguration.kt
+++ b/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionApiConfiguration.kt
@@ -1,0 +1,71 @@
+package io.propagandist.recibir.reconcile
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+/**
+ * 突き合わせが使う HTTP クライアントを組み立てる。
+ *
+ * **依存を増やしていない。** `RestClient` は `spring-boot-starter-webmvc` が引く
+ * `spring-web` に入っている。HTTP クライアントのライブラリも、テスト用のスタブサーバも足さない。
+ *
+ * **`RestClient.Builder` を注入していない。** Boot 4 の `spring-boot-starter-webmvc` は
+ * その Bean を auto-configure しない——`spring-boot-restclient` が classpath に入らないためで、
+ * 注入しようとすると `NoSuchBeanDefinitionException` で起動が止まる（2026-08-29 実測）。
+ * **スターターを 1 本足すより、`RestClient.builder()` を自分で呼ぶほうが依存が増えない。**
+ */
+@Configuration
+class SuppressionApiConfiguration {
+    /**
+     * API キーを設定から読み、クライアントを組み立てる。
+     *
+     * **既定値を書かない。** 公開鍵と同じ扱いで（`webhook/SendGridWebhookConfiguration`）、
+     * 環境変数が無ければ起動が止まる。**「キーが無ければ突き合わせを止める」形にしない**
+     * ——設定による挙動の切り替えであり、`CLAUDE.md`「最重要」が禁じている。
+     * 止まるなら、起動時に止まるほうが読める。
+     */
+    @Bean
+    fun suppressionApiClient(
+        @Value("\${sendgrid.api.key}") apiKey: String,
+    ): SuppressionApiClient = SuppressionApiClient(sendGridRestClient(RestClient.builder().requestFactory(timeouts()), apiKey))
+
+    /**
+     * 応答を待つ上限。
+     *
+     * **既定は無制限である。** 日次バッチなので急がないが、上限が無いと
+     * SendGrid が応答しない日に**スケジューラのスレッドが戻ってこない**
+     * ——[SuppressionApiClient] がページ数に上限を置いたのと同じ理由である。
+     *
+     * **設定項目にしない**（`docs/SPEC.md` §5）。
+     */
+    private fun timeouts() =
+        SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(Duration.ofSeconds(10))
+            setReadTimeout(Duration.ofSeconds(30))
+        }
+}
+
+/** SendGrid API の入口。**EU アカウントは `api.eu.sendgrid.com` になる**（2026-08-29 に確認）。 */
+internal const val SENDGRID_API_BASE_URL = "https://api.sendgrid.com"
+
+/**
+ * 認証済みのクライアントを作る。
+ *
+ * **関数に切り出してあるのは、テストが同じ組み立てを通せるようにするため**である
+ * ——`Authorization` が付くことは、Bean を組み立てる側ではなく**出ていくリクエスト**で
+ * 確かめたい。**`requestFactory` はここで触らない**。触ると、テストが差し込むスタブを
+ * 上書きしてしまう。
+ */
+internal fun sendGridRestClient(
+    builder: RestClient.Builder,
+    apiKey: String,
+): RestClient =
+    builder
+        .baseUrl(SENDGRID_API_BASE_URL)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $apiKey")
+        .build()

--- a/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionReconciler.kt
+++ b/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionReconciler.kt
@@ -1,0 +1,159 @@
+package io.propagandist.recibir.reconcile
+
+import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
+import org.jooq.DSLContext
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.OffsetDateTime
+
+/**
+ * Suppression API と `email_address_state` を突き合わせる（`docs/SPEC.md` §4.5）。
+ *
+ * **Webhook の取りこぼしは起きる前提である**（`README.md`「Webhook を信頼しない」）。
+ * 受信できなかったイベントは `sendgrid_event` に無く、したがって射影にも出ない
+ * ——**送れないアドレスへ、静かに送り続ける。** ここが、その量を測る唯一の経路になる。
+ *
+ * ## 落とす方向にしか書かない
+ *
+ * **SendGrid 側に無いものを、こちらから消さない。** 抑制リストは運用者が手で外すことがあり、
+ * それを「送ってよくなった」と読むと、**外した瞬間に過去のバウンス先へ送り始める。**
+ *
+ * ## `blocks` は状態を書き換えない
+ *
+ * `blocks` は**一時的な失敗**である（§4.4 は `blocked` で `sendable` を落とさない）。
+ * リストに載ったアドレスは、SendGrid 側が解消を検知すれば外れる。ここで `sendable` を
+ * 落とすと、**外れた日に戻す手段が無い**——§4.4 の優先度は一度落ちたら戻らない形なので、
+ * 単調でないものを表現できない。
+ *
+ * だから `blocks` で数えるのは「**行が 1 つも無いアドレス**」だけとする。それは
+ * 「そのアドレスのイベントを 1 件も受け取っていない」を意味し、**完全な取りこぼしの指標**になる。
+ * 行があって `sendable = true` なのは正常な状態なので、数えない。
+ *
+ * ## 射影が上書きしうることを、分岐で塞がない
+ *
+ * [io.propagandist.recibir.event.EventProjector] は `sendgrid_event` に出てくるアドレスだけを
+ * 回すので、**イベントが 1 件も無いアドレス**——取りこぼしの本体——には触れない。
+ * イベントもあるアドレスで `invalid` が上書きされる筋は残るが、そのとき射影が書くのは
+ * `hard_bounce` か `dropped` 由来の NULL で、**`sendable` は false のままである。**
+ * 失われるのは `reason_code` の精度だけで、翌日の突き合わせが書き戻す。
+ *
+ * **射影側に「ここが書いた行は触らない」分岐を足すと、`email_address_state` が
+ * `sendgrid_event` から再構築できなくなる**（同 §3.2）。二次テーブルであることをやめない。
+ */
+@Service
+class SuppressionReconciler(
+    private val apiClient: SuppressionApiClient,
+    private val dsl: DSLContext,
+) {
+    /**
+     * 4 つのリストを順に突き合わせる。
+     *
+     * **`zone` を書かないと JVM の既定に従い、動かす環境で時刻が変わる。**
+     * 時刻そのものに意味は無いが、環境で変わらないことには意味がある。
+     *
+     * **1 つの source で失敗したら、残りも止まる。** 部分的に成功すると、
+     * drift の数字が「どこまで見たか」を含まなくなる。例外はスケジューラが ERROR として残し、
+     * 翌日また全部をやり直す——**日次バッチなので、1 日遅れても取りこぼしは消えない。**
+     */
+    @Scheduled(cron = DAILY_AT_0300, zone = "UTC")
+    fun reconcile() {
+        // 開始時点で 1 度だけ読む。**drift の判定を実行順に依存させない**
+        // ——補完で書いた分を反映すると、後の source ほど差分が小さく見える
+        val known = knownAddresses()
+        val unsendable = unsendableAddresses()
+        // 既に補完したアドレス。**優先度の高い source が書いたものを、後から上書きしない**
+        // （並び順が優先度である。[SuppressionSource] の KDoc）
+        val corrected = mutableSetOf<String>()
+
+        SuppressionSource.entries.forEach { source ->
+            val remote = apiClient.fetch(source)
+            val reasonCode = source.reasonCode
+            // reasonCode を持たないのは blocks だけで、そちらは「行があるか」だけを見る（KDoc）
+            val drifted = remote - if (reasonCode == null) known else unsendable
+            if (reasonCode != null) {
+                (drifted - corrected).forEach { correct(it, reasonCode) }
+                corrected += drifted
+            }
+            report(source, remote.size, drifted.size)
+        }
+    }
+
+    /**
+     * `email_address_state` にある全アドレス。`blocks` は、ここに無いものだけを差分と数える。
+     *
+     * **1 件ずつ問い合わせない。** 抑制リストは数千件になりうるので、そのぶん往復すると
+     * 日次バッチが往復だけで終わる。**集合どうしの差を取るほうが短い。**
+     */
+    private fun knownAddresses(): Set<String> =
+        dsl
+            .select(EMAIL_ADDRESS_STATE.EMAIL)
+            .from(EMAIL_ADDRESS_STATE)
+            .fetchSet(EMAIL_ADDRESS_STATE.EMAIL)
+
+    /** 送れない印が付いているアドレス。`blocks` 以外は、ここに無いものを差分と数える。 */
+    private fun unsendableAddresses(): Set<String> =
+        dsl
+            .select(EMAIL_ADDRESS_STATE.EMAIL)
+            .from(EMAIL_ADDRESS_STATE)
+            .where(EMAIL_ADDRESS_STATE.SENDABLE.isFalse)
+            .fetchSet(EMAIL_ADDRESS_STATE.EMAIL)
+
+    /**
+     * 1 行を、送れない側へ倒す。
+     *
+     * **`last_failure_at` と `soft_bounce_count` を触らない。** どちらも Webhook 由来の値で、
+     * Suppression API の `created` は「リストに載った時刻」である（[SuppressionApiClient]）。
+     * **射影と違って `newRecord` をまるごと渡さないのはこのため**——あちらは全列を導出し直すが、
+     * ここが知っているのは 2 列だけである。
+     */
+    private fun correct(
+        email: String,
+        reasonCode: String,
+    ) {
+        val now = OffsetDateTime.now()
+        dsl
+            .insertInto(EMAIL_ADDRESS_STATE)
+            .set(EMAIL_ADDRESS_STATE.EMAIL, email)
+            .set(EMAIL_ADDRESS_STATE.SENDABLE, false)
+            .set(EMAIL_ADDRESS_STATE.REASON_CODE, reasonCode)
+            .set(EMAIL_ADDRESS_STATE.UPDATED_AT, now)
+            .onConflict(EMAIL_ADDRESS_STATE.EMAIL)
+            .doUpdate()
+            .set(EMAIL_ADDRESS_STATE.SENDABLE, false)
+            .set(EMAIL_ADDRESS_STATE.REASON_CODE, reasonCode)
+            .set(EMAIL_ADDRESS_STATE.UPDATED_AT, now)
+            .execute()
+    }
+
+    /**
+     * 突き合わせた結果を残す。
+     *
+     * **差分が無ければ `reconcile.drift` を出さない。** 毎日 WARNING が出続けると、
+     * 監視の側に**無視する習慣**ができる。突き合わせが動いていること自体は、
+     * `event` キーを持たない素の行が担う——`docs/SPEC.md` §4.7 の表は
+     * 「運用が条件にするもの」の一覧なので、そこを増やさない。
+     */
+    private fun report(
+        source: SuppressionSource,
+        fetched: Int,
+        drifted: Int,
+    ) {
+        log.info("reconciled {} entries from {}", fetched, source.label)
+        if (drifted == 0) return
+        log
+            .atWarn()
+            .addKeyValue("event", "reconcile.drift")
+            .addKeyValue("source", source.label)
+            .addKeyValue("count", drifted)
+            // **アドレスは載せない**（同 §4.7）。件数で足り、どれかを知るには DB を引く
+            .log("found addresses that the webhook did not deliver")
+    }
+
+    private companion object {
+        val log = LoggerFactory.getLogger(SuppressionReconciler::class.java)
+
+        /** 毎日 03:00。**時刻そのものに意味は無い**（日次 4 リクエストはレート制限に触れない）。 */
+        const val DAILY_AT_0300 = "0 0 3 * * *"
+    }
+}

--- a/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionSource.kt
+++ b/src/main/kotlin/io/propagandist/recibir/reconcile/SuppressionSource.kt
@@ -1,0 +1,38 @@
+package io.propagandist.recibir.reconcile
+
+/**
+ * 突き合わせる Suppression API のリスト（`docs/SPEC.md` §4.5）。
+ *
+ * **並び順が補完の優先度である。** 同じアドレスが 2 つのリストに載っていることはあり、
+ * 先に当たったものの [reasonCode] が残る。順は `docs/SPEC.md` §4.4 の状態決定に合わせてある
+ * ——`spamreport` が `bounce` より強い。
+ *
+ * 4 つとも `limit`（最大 500）／ `offset` ／ `start_time` ／ `end_time` ／ `email` を受け、
+ * 応答は配列である（2026-08-29 に原文で確認）。**共通するのは `created` と `email` だけ**で、
+ * `spam_reports` は `reason` を持たず `ip` を持つ。
+ *
+ * @property path `https://api.sendgrid.com` からのパス
+ * @property reasonCode 補完するときに書く値。**`null` は「状態を書き換えない」を意味する**
+ *   ——[SuppressionReconciler] の KDoc にその理由がある
+ */
+enum class SuppressionSource(
+    val path: String,
+    val reasonCode: String?,
+) {
+    SPAM_REPORTS("/v3/suppression/spam_reports", "spam_report"),
+    BOUNCES("/v3/suppression/bounces", "hard_bounce"),
+
+    /** `invalid` を付けられるのはここだけである（`docs/SPEC.md` §3.2 の 4 つ目）。 */
+    INVALID_EMAILS("/v3/suppression/invalid_emails", "invalid"),
+
+    /** **一時的な失敗なので状態を書き換えない**（[SuppressionReconciler] の KDoc）。 */
+    BLOCKS("/v3/suppression/blocks", null),
+    ;
+
+    /**
+     * ログの `source` に出す名前。
+     *
+     * **パスの末尾から取る。** 別に定数を置くと、パスと名前が食い違う形ができる。
+     */
+    val label: String get() = path.substringAfterLast('/')
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,8 @@ logging:
 sendgrid:
   webhook:
     public-key: ${SENDGRID_WEBHOOK_PUBLIC_KEY}
+  # Suppression API との突き合わせ（docs/SPEC.md §4.5）が使う。
+  # ここも既定値を書かない。空を既定にすると、キーを設定し忘れたまま起動でき、
+  # 突き合わせが 401 で失敗し続けるのに受信だけは動いている状態になる。
+  api:
+    key: ${SENDGRID_API_KEY}

--- a/src/test/kotlin/io/propagandist/recibir/config/CloudLoggingFormatTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/config/CloudLoggingFormatTest.kt
@@ -1,7 +1,7 @@
 package io.propagandist.recibir.config
 
 import io.propagandist.recibir.support.PostgresContainer
-import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.LoggerFactory
@@ -119,8 +119,7 @@ class CloudLoggingFormatTest {
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
             PostgresContainer.register(registry)
-            // コンテキストを起動するには鍵が要る（SendGridWebhookConfiguration）
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(TestKeyPair.generate()) }
+            registerSendGridProperties(registry)
         }
     }
 }

--- a/src/test/kotlin/io/propagandist/recibir/event/EventProjectorTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/event/EventProjectorTest.kt
@@ -3,7 +3,7 @@ package io.propagandist.recibir.event
 import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
 import io.propagandist.jooq.Tables.SENDGRID_EVENT
 import io.propagandist.recibir.support.PostgresContainer
-import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import io.propagandist.recibir.support.structuredLogs
 import org.jooq.DSLContext
 import org.jooq.JSONB
@@ -252,9 +252,7 @@ class EventProjectorTest {
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
             PostgresContainer.register(registry)
-            // 射影は署名を見ないが、コンテキストを起動するには鍵が要る
-            // （SendGridWebhookConfiguration。既定値を置いていない）
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(TestKeyPair.generate()) }
+            registerSendGridProperties(registry)
         }
     }
 }

--- a/src/test/kotlin/io/propagandist/recibir/event/RebuildAllRunnerTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/event/RebuildAllRunnerTest.kt
@@ -3,7 +3,7 @@ package io.propagandist.recibir.event
 import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
 import io.propagandist.jooq.Tables.SENDGRID_EVENT
 import io.propagandist.recibir.support.PostgresContainer
-import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import org.jooq.DSLContext
 import org.jooq.JSONB
 import org.junit.jupiter.api.BeforeEach
@@ -75,7 +75,7 @@ class RebuildAllRunnerTest {
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
             PostgresContainer.register(registry)
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(TestKeyPair.generate()) }
+            registerSendGridProperties(registry)
         }
     }
 }

--- a/src/test/kotlin/io/propagandist/recibir/reconcile/SuppressionApiClientTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/reconcile/SuppressionApiClientTest.kt
@@ -1,0 +1,163 @@
+package io.propagandist.recibir.reconcile
+
+import io.propagandist.recibir.support.TEST_API_KEY
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.ExpectedCount
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.anything
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.test.web.client.response.MockRestResponseCreators.withUnauthorizedRequest
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+/**
+ * Suppression API の読み方を確かめる。**ネットワークにも SendGrid アカウントにも触らない。**
+ *
+ * `MockRestServiceServer` でスタブする（`spring-test`）。**WireMock を入れていない**
+ * ——ここで要るのは「出ていくリクエストの形」と「返ってきた配列の読み方」だけである。
+ *
+ * 組み立ては [sendGridRestClient] を通す。`Authorization` が付くことは、
+ * Bean を組み立てる側ではなく**出ていくリクエスト**で確かめたい。
+ */
+class SuppressionApiClientTest {
+    private val builder = RestClient.builder()
+    private val server = MockRestServiceServer.bindTo(builder).build()
+    private val client = SuppressionApiClient(sendGridRestClient(builder, TEST_API_KEY))
+
+    /** `email` だけを持つ応答を作る。他のフィールドは読まないので置かない。 */
+    private fun entries(
+        count: Int,
+        prefix: String = "u",
+    ) = (0 until count).joinToString(",", "[", "]") { """{"email":"$prefix$it@example.com"}""" }
+
+    private fun respondWith(
+        body: String,
+        count: ExpectedCount = ExpectedCount.once(),
+    ) = server.expect(count, anything()).andRespond(withSuccess(body, MediaType.APPLICATION_JSON))
+
+    @Test
+    fun `Authorization に Bearer が付く`() {
+        server
+            .expect(anything())
+            .andExpect(header("Authorization", "Bearer $TEST_API_KEY"))
+            .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON))
+
+        client.fetch(SuppressionSource.BOUNCES)
+
+        server.verify()
+    }
+
+    @Test
+    fun `叩く先は api_sendgrid_com のパスで、1 ページ目の offset は 0`() {
+        server
+            .expect(requestTo("https://api.sendgrid.com/v3/suppression/bounces?limit=500&offset=0"))
+            .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON))
+
+        client.fetch(SuppressionSource.BOUNCES)
+
+        server.verify()
+    }
+
+    @Test
+    fun `source ごとに違うパスを叩く`() {
+        // パスと source の対応が入れ替わると、別のリストの reason_code が付く
+        SuppressionSource.entries.forEach { source ->
+            val each = RestClient.builder()
+            val stub = MockRestServiceServer.bindTo(each).build()
+            stub
+                .expect(requestTo("https://api.sendgrid.com${source.path}?limit=500&offset=0"))
+                .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON))
+
+            SuppressionApiClient(sendGridRestClient(each, TEST_API_KEY)).fetch(source)
+
+            stub.verify()
+        }
+    }
+
+    @Test
+    fun `ログに出す label はパスの末尾と同じ`() {
+        assertEquals("spam_reports", SuppressionSource.SPAM_REPORTS.label)
+        assertEquals("bounces", SuppressionSource.BOUNCES.label)
+        assertEquals("invalid_emails", SuppressionSource.INVALID_EMAILS.label)
+        assertEquals("blocks", SuppressionSource.BLOCKS.label)
+    }
+
+    @Test
+    fun `500 件返ると次のページを取りに行く`() {
+        server
+            .expect(queryParam("offset", "0"))
+            .andRespond(withSuccess(entries(500, "a"), MediaType.APPLICATION_JSON))
+        server
+            .expect(queryParam("offset", "500"))
+            .andRespond(withSuccess(entries(3, "b"), MediaType.APPLICATION_JSON))
+
+        val emails = client.fetch(SuppressionSource.BOUNCES)
+
+        assertEquals(503, emails.size)
+        server.verify()
+    }
+
+    @Test
+    fun `500 件に満たなければそこで終わる`() {
+        respondWith(entries(4))
+
+        val emails = client.fetch(SuppressionSource.BOUNCES)
+
+        assertEquals(4, emails.size)
+        // 2 ページ目を取りに行っていたら、スタブが尽きて落ちる
+        server.verify()
+    }
+
+    @Test
+    fun `空のリストでも壊れない`() {
+        respondWith("[]")
+
+        assertEquals(emptySet(), client.fetch(SuppressionSource.BLOCKS))
+    }
+
+    @Test
+    fun `同じページが返り続けても上限で止まる`() {
+        // これが無いと、SendGrid が同じページを返した日に日次バッチが終わらなくなる
+        respondWith(entries(500), ExpectedCount.times(SuppressionApiClient.MAX_PAGES))
+
+        val emails = client.fetch(SuppressionSource.BOUNCES)
+
+        // 毎回同じアドレスなので、集合は 1 ページ分のまま
+        assertEquals(500, emails.size)
+        server.verify()
+    }
+
+    @Test
+    fun `spam_reports の応答に reason が無くても読める`() {
+        // 4 つのうちここだけ形が違う（reason を持たず ip を持つ。2026-08-29 に原文で確認）
+        respondWith("""[{"created":1443651141,"email":"user1@example.com","ip":"10.63.202.100"}]""")
+
+        assertEquals(setOf("user1@example.com"), client.fetch(SuppressionSource.SPAM_REPORTS))
+    }
+
+    @Test
+    fun `知らないフィールドが増えても読める`() {
+        // SendGrid はフィールドを予告なく足す（README「生 JSON を捨てない」）
+        respondWith("""[{"email":"user@example.com","added_later":{"nested":true}}]""")
+
+        assertEquals(setOf("user@example.com"), client.fetch(SuppressionSource.BOUNCES))
+    }
+
+    @Test
+    fun `401 のとき、例外に API キーが出ない`() {
+        // 例外はそのまま上がってログに出る。そこへ鍵が混ざると、履歴に残る形で漏れる
+        server.expect(anything()).andRespond(withUnauthorizedRequest())
+
+        val thrown = assertFailsWith<RestClientResponseException> { client.fetch(SuppressionSource.BOUNCES) }
+
+        assertFalse(thrown.toString().contains(TEST_API_KEY), thrown.toString())
+        assertFalse(thrown.message.orEmpty().contains("Bearer"), thrown.message.orEmpty())
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/reconcile/SuppressionReconcilerTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/reconcile/SuppressionReconcilerTest.kt
@@ -1,0 +1,254 @@
+package io.propagandist.recibir.reconcile
+
+import io.propagandist.jooq.Tables.EMAIL_ADDRESS_STATE
+import io.propagandist.jooq.Tables.SENDGRID_EVENT
+import io.propagandist.recibir.support.PostgresContainer
+import io.propagandist.recibir.support.TEST_API_KEY
+import io.propagandist.recibir.support.registerSendGridProperties
+import io.propagandist.recibir.support.structuredLogs
+import org.jooq.DSLContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+import org.springframework.http.MediaType
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * 突き合わせの結果——**何を書き、何を数え、何に触らないか**——を確かめる。
+ *
+ * SendGrid は `MockRestServiceServer` でスタブし、DB は Testcontainers が立てる。
+ * **SendGrid アカウントもネットワークも要らない**（`docs/SPEC.md` §6）。**Docker は要る。**
+ *
+ * 突き合わせは自分で組み立てる。Bean のほうは本物の HTTP クライアントを持つが、
+ * 日次 03:00 UTC まで動かないので、テストの最中には出ていかない。
+ */
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension::class)
+class SuppressionReconcilerTest {
+    @Autowired
+    private lateinit var dsl: DSLContext
+
+    private val builder = RestClient.builder()
+    private val server = MockRestServiceServer.bindTo(builder).ignoreExpectOrder(true).build()
+    private val reconciler by lazy {
+        SuppressionReconciler(SuppressionApiClient(sendGridRestClient(builder, TEST_API_KEY)), dsl)
+    }
+
+    @BeforeEach
+    fun clean() {
+        // **sendgrid_event も空にする。** 射影のスケジューラが同じ DB を見ているので、
+        // 残っていると、突き合わせが書いたのか射影が書いたのか読めなくなる
+        dsl.deleteFrom(SENDGRID_EVENT).execute()
+        dsl.deleteFrom(EMAIL_ADDRESS_STATE).execute()
+    }
+
+    /**
+     * 4 つのリストに何が載っているかを決める。**指定しなかったものは空で返る。**
+     *
+     * 4 つとも叩かれるので、1 つでもスタブが欠けるとそこで落ちる。
+     */
+    private fun stub(vararg lists: Pair<SuppressionSource, List<String>>) {
+        val given = lists.toMap()
+        SuppressionSource.entries.forEach { source ->
+            val body = given[source].orEmpty().joinToString(",", "[", "]") { """{"email":"$it"}""" }
+            server
+                .expect(requestTo("https://api.sendgrid.com${source.path}?limit=500&offset=0"))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON))
+        }
+    }
+
+    private fun givenState(
+        email: String,
+        sendable: Boolean,
+        reasonCode: String? = null,
+        softBounceCount: Int = 0,
+        lastFailureAt: OffsetDateTime? = null,
+    ) {
+        dsl
+            .insertInto(EMAIL_ADDRESS_STATE)
+            .set(EMAIL_ADDRESS_STATE.EMAIL, email)
+            .set(EMAIL_ADDRESS_STATE.SENDABLE, sendable)
+            .set(EMAIL_ADDRESS_STATE.REASON_CODE, reasonCode)
+            .set(EMAIL_ADDRESS_STATE.SOFT_BOUNCE_COUNT, softBounceCount)
+            .set(EMAIL_ADDRESS_STATE.LAST_FAILURE_AT, lastFailureAt)
+            .set(EMAIL_ADDRESS_STATE.UPDATED_AT, OffsetDateTime.now())
+            .execute()
+    }
+
+    private fun state(email: String) = dsl.fetchOne(EMAIL_ADDRESS_STATE, EMAIL_ADDRESS_STATE.EMAIL.eq(email))
+
+    @Test
+    fun `4 つのリストを全部叩く`() {
+        stub()
+
+        reconciler.reconcile()
+
+        server.verify()
+    }
+
+    @Test
+    fun `bounces にあって行が無いアドレスへ hard_bounce が書かれる`() {
+        // Webhook を取りこぼしたアドレスの本体。ここが埋まらないと、送り続けることになる
+        stub(SuppressionSource.BOUNCES to listOf("gone@example.com"))
+
+        reconciler.reconcile()
+
+        val row = state("gone@example.com")!!
+        assertFalse(row.sendable)
+        assertEquals("hard_bounce", row.reasonCode)
+    }
+
+    @Test
+    fun `invalid_emails 由来の reason_code は invalid`() {
+        // invalid を付けられるのはここだけである（docs/SPEC.md §3.2 の 4 つ目）
+        stub(SuppressionSource.INVALID_EMAILS to listOf("nodomain@example.invalid"))
+
+        reconciler.reconcile()
+
+        assertEquals("invalid", state("nodomain@example.invalid")!!.reasonCode)
+    }
+
+    @Test
+    fun `spam_reports 由来の reason_code は spam_report`() {
+        stub(SuppressionSource.SPAM_REPORTS to listOf("angry@example.com"))
+
+        reconciler.reconcile()
+
+        assertEquals("spam_report", state("angry@example.com")!!.reasonCode)
+    }
+
+    @Test
+    fun `blocks では状態が書き換わらない`() {
+        // 一時的な失敗である。落とすと、SendGrid 側が外した日に戻す手段が無い
+        stub(SuppressionSource.BLOCKS to listOf("blocked@example.com"))
+
+        reconciler.reconcile()
+
+        assertNull(state("blocked@example.com"))
+    }
+
+    @Test
+    fun `blocks の差分は、行が無いものだけを数える`(output: CapturedOutput) {
+        // 行があって sendable = true なのは正常な状態である（blocked は sendable を落とさない）
+        givenState("known@example.com", sendable = true)
+        stub(SuppressionSource.BLOCKS to listOf("known@example.com", "unknown@example.com"))
+
+        reconciler.reconcile()
+
+        val drift = structuredLogs(output, "reconcile.drift").single()
+        assertEquals("blocks", drift["source"].stringValue())
+        assertEquals(1, drift["count"].intValue())
+    }
+
+    @Test
+    fun `SendGrid 側に無いアドレスの sendable は true へ戻らない`() {
+        // 抑制リストは運用者が手で外すことがある。戻すと、その瞬間に過去のバウンス先へ送り始める
+        givenState("bounced@example.com", sendable = false, reasonCode = "hard_bounce")
+        stub()
+
+        reconciler.reconcile()
+
+        val row = state("bounced@example.com")!!
+        assertFalse(row.sendable)
+        assertEquals("hard_bounce", row.reasonCode)
+    }
+
+    @Test
+    fun `既に送れない印が付いていれば差分に数えない`(output: CapturedOutput) {
+        givenState("known@example.com", sendable = false, reasonCode = "hard_bounce")
+        stub(SuppressionSource.BOUNCES to listOf("known@example.com"))
+
+        reconciler.reconcile()
+
+        assertTrue(structuredLogs(output, "reconcile.drift").isEmpty())
+    }
+
+    @Test
+    fun `2 つのリストに載っていたら、優先度の高いほうの reason_code が残る`() {
+        // 並び順が優先度である（SuppressionSource の KDoc）。spamreport が bounce より強い
+        stub(
+            SuppressionSource.SPAM_REPORTS to listOf("both@example.com"),
+            SuppressionSource.BOUNCES to listOf("both@example.com"),
+        )
+
+        reconciler.reconcile()
+
+        assertEquals("spam_report", state("both@example.com")!!.reasonCode)
+    }
+
+    @Test
+    fun `last_failure_at と soft_bounce_count には触らない`() {
+        // どちらも Webhook 由来の値である。Suppression API の created は
+        // 「リストに載った時刻」で、意味が違う（SuppressionApiClient の KDoc）
+        // マイクロ秒へ丸める。**timestamptz はそこまでしか持たない**ので、
+        // ナノ秒のまま入れると、読み戻した値が入れた値と一致しない（2026-08-29 実測）
+        val failedAt = OffsetDateTime.now().minusDays(3).truncatedTo(ChronoUnit.MICROS)
+        givenState("soft@example.com", sendable = true, softBounceCount = 5, lastFailureAt = failedAt)
+        stub(SuppressionSource.BOUNCES to listOf("soft@example.com"))
+
+        reconciler.reconcile()
+
+        val row = state("soft@example.com")!!
+        assertFalse(row.sendable)
+        assertEquals(5, row.softBounceCount)
+        assertEquals(failedAt.toInstant(), row.lastFailureAt?.toInstant())
+    }
+
+    @Test
+    fun `差分が 0 なら reconcile_drift は出ない`(output: CapturedOutput) {
+        // 毎日 WARNING が出続けると、監視の側に無視する習慣ができる
+        stub()
+
+        reconciler.reconcile()
+
+        assertTrue(structuredLogs(output, "reconcile.drift").isEmpty())
+    }
+
+    @Test
+    fun `reconcile_drift は WARNING で、件数と source を持つ`(output: CapturedOutput) {
+        stub(SuppressionSource.BOUNCES to listOf("a@example.com", "b@example.com"))
+
+        reconciler.reconcile()
+
+        val drift = structuredLogs(output, "reconcile.drift").single()
+        assertEquals("WARNING", drift["severity"].stringValue())
+        assertEquals("bounces", drift["source"].stringValue())
+        assertEquals(2, drift["count"].intValue())
+    }
+
+    @Test
+    fun `reconcile_drift にメールアドレスが載らない`(output: CapturedOutput) {
+        // 件数で足りる。どれかを知るには DB を引く（docs/SPEC.md §4.7）
+        stub(SuppressionSource.BOUNCES to listOf("secret@example.com"))
+
+        reconciler.reconcile()
+
+        val drift = structuredLogs(output, "reconcile.drift").single().toString()
+        assertFalse(drift.contains("secret"), drift)
+        assertFalse(drift.contains("example.com"), drift)
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            PostgresContainer.register(registry)
+            registerSendGridProperties(registry)
+        }
+    }
+}

--- a/src/test/kotlin/io/propagandist/recibir/support/SendGridProperties.kt
+++ b/src/test/kotlin/io/propagandist/recibir/support/SendGridProperties.kt
@@ -1,0 +1,23 @@
+package io.propagandist.recibir.support
+
+import org.springframework.test.context.DynamicPropertyRegistry
+
+/**
+ * SendGrid まわりの設定を、テストのコンテキストへ流し込む。
+ *
+ * **どれも既定値を持たない**ので、1 つでも欠けるとコンテキストが起動しない
+ * ——**設定の付け忘れを起動時に落とす**ための構えである
+ * （`webhook/SendGridWebhookConfiguration`）。テストの側では、その全部をここが埋める。
+ *
+ * 署名を見ないテストでも鍵が要るのはこのためで、**各テストがその事情を書く必要は無い。**
+ * DB は用途が別なので、要るテストだけが [PostgresContainer] を呼ぶ。
+ *
+ * @param publicKey 署名を検証するテストは、自分が署名に使った鍵ペアの公開鍵を渡す。
+ *   省略すると使い捨ての鍵になる
+ */
+fun registerSendGridProperties(
+    registry: DynamicPropertyRegistry,
+    publicKey: String = TestKeyPair.publicKeyBase64(TestKeyPair.generate()),
+) {
+    registry.add("sendgrid.webhook.public-key") { publicKey }
+}

--- a/src/test/kotlin/io/propagandist/recibir/support/SendGridProperties.kt
+++ b/src/test/kotlin/io/propagandist/recibir/support/SendGridProperties.kt
@@ -7,7 +7,8 @@ import org.springframework.test.context.DynamicPropertyRegistry
  *
  * **どれも既定値を持たない**ので、1 つでも欠けるとコンテキストが起動しない
  * ——**設定の付け忘れを起動時に落とす**ための構えである
- * （`webhook/SendGridWebhookConfiguration`）。テストの側では、その全部をここが埋める。
+ * （`webhook/SendGridWebhookConfiguration` ／ `reconcile/SuppressionApiConfiguration`）。
+ * テストの側では、その全部をここが埋める。
  *
  * 署名を見ないテストでも鍵が要るのはこのためで、**各テストがその事情を書く必要は無い。**
  * DB は用途が別なので、要るテストだけが [PostgresContainer] を呼ぶ。
@@ -20,4 +21,12 @@ fun registerSendGridProperties(
     publicKey: String = TestKeyPair.publicKeyBase64(TestKeyPair.generate()),
 ) {
     registry.add("sendgrid.webhook.public-key") { publicKey }
+    registry.add("sendgrid.api.key") { TEST_API_KEY }
 }
+
+/**
+ * テストが使う API キー。**本物ではない。** 形だけ SendGrid のものに似せてある。
+ *
+ * ネットワークへは出ない——突き合わせのテストは `MockRestServiceServer` でスタブする。
+ */
+const val TEST_API_KEY = "SG.test-key-not-a-real-one"

--- a/src/test/kotlin/io/propagandist/recibir/webhook/SendGridEventIngestServiceTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/SendGridEventIngestServiceTest.kt
@@ -2,7 +2,7 @@ package io.propagandist.recibir.webhook
 
 import io.propagandist.jooq.Tables.SENDGRID_EVENT
 import io.propagandist.recibir.support.PostgresContainer
-import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import org.jooq.DSLContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -177,9 +177,7 @@ class SendGridEventIngestServiceTest {
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
             PostgresContainer.register(registry)
-            // 投入は署名を見ないが、コンテキストを起動するには鍵が要る
-            // （SendGridWebhookConfiguration。既定値を置いていない）
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(TestKeyPair.generate()) }
+            registerSendGridProperties(registry)
         }
     }
 }

--- a/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookControllerTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookControllerTest.kt
@@ -2,6 +2,7 @@ package io.propagandist.recibir.webhook
 
 import io.propagandist.recibir.config.SecurityConfig
 import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -127,7 +128,7 @@ class SendGridWebhookControllerTest {
         @JvmStatic
         @DynamicPropertySource
         fun publicKey(registry: DynamicPropertyRegistry) {
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(KEY_PAIR) }
+            registerSendGridProperties(registry, TestKeyPair.publicKeyBase64(KEY_PAIR))
         }
     }
 }

--- a/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookIngestTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/SendGridWebhookIngestTest.kt
@@ -3,6 +3,7 @@ package io.propagandist.recibir.webhook
 import io.propagandist.jooq.Tables.SENDGRID_EVENT
 import io.propagandist.recibir.support.PostgresContainer
 import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import org.jooq.DSLContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -108,7 +109,7 @@ class SendGridWebhookIngestTest {
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
             PostgresContainer.register(registry)
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(KEY_PAIR) }
+            registerSendGridProperties(registry, TestKeyPair.publicKeyBase64(KEY_PAIR))
         }
     }
 }

--- a/src/test/kotlin/io/propagandist/recibir/webhook/WebhookLoggingTest.kt
+++ b/src/test/kotlin/io/propagandist/recibir/webhook/WebhookLoggingTest.kt
@@ -3,6 +3,7 @@ package io.propagandist.recibir.webhook
 import io.propagandist.jooq.Tables.SENDGRID_EVENT
 import io.propagandist.recibir.support.PostgresContainer
 import io.propagandist.recibir.support.TestKeyPair
+import io.propagandist.recibir.support.registerSendGridProperties
 import io.propagandist.recibir.support.structuredLogs
 import org.jooq.DSLContext
 import org.junit.jupiter.api.BeforeEach
@@ -185,7 +186,7 @@ class WebhookLoggingTest {
         @DynamicPropertySource
         fun properties(registry: DynamicPropertyRegistry) {
             PostgresContainer.register(registry)
-            registry.add("sendgrid.webhook.public-key") { TestKeyPair.publicKeyBase64(KEY_PAIR) }
+            registerSendGridProperties(registry, TestKeyPair.publicKeyBase64(KEY_PAIR))
         }
     }
 }


### PR DESCRIPTION
Suppression API と `email_address_state` を突き合わせる層を入れる（#40。`docs/HANDOVER.md` の作業順序 9）。
**Webhook の取りこぼしは起きる前提**なのに、起きたことに気づく経路が 1 本も無かった。
#5 の最後の 1 つ（`reconcile.drift`）もここで埋まる。

**マージ方式の都合で、コミットの本文は既定ブランチの履歴に残らない**（org `work-conventions.md` §5）。
判断はここへまとめる。

## 判断とその理由

### 全件を取る。前回いつ実行したかを記録しない

`start_time` / `end_time` で絞らない。**期間で絞ると、取りこぼしは窓の外に落ちたまま
永久に見つからない**——それは、まさに検出したいものである。「前回いつ実行したか」も
持たない（#34 / #36 と同じ理由で、捨てて作り直せない状態を増やさない）。

### `blocks` は状態を書き換えず、行が無いものだけを数える

`blocks` は一時的な失敗である（§4.4 は `blocked` で `sendable` を落とさない）。
落とすと **SendGrid 側が外した日に戻す手段が無い**——§4.4 の優先度は一度落ちたら
戻らない形なので、単調でないものを表現できない。

数えるのは「`email_address_state` に行が 1 つも無いアドレス」だけとした。
それは「そのアドレスのイベントを 1 件も受け取っていない」を意味し、**完全な取りこぼしの指標**になる。

### 落とす方向にしか書かない

**SendGrid 側に無いものを、こちらから消さない。** 抑制リストは運用者が手で外すことがあり、
それを「送ってよくなった」と読むと、**外した瞬間に過去のバウンス先へ送り始める。**

`last_failure_at` と `soft_bounce_count` にも触らない。どちらも Webhook 由来の値で、
Suppression API の `created` は「リストに載った時刻」である。

### 射影が上書きしうることを、分岐で塞がない

`docs/HANDOVER.md` の未決事項（#39 で置いた）への答えである。射影は `sendgrid_event` に
出てくるアドレスだけを回すので、**取りこぼしの本体には触れない**。イベントもある
アドレスで `invalid` が上書きされる筋は残るが、`sendable` は false のままで、
失われるのは `reason_code` の精度だけである。

**塞ぐと `email_address_state` が `sendgrid_event` から再構築できなくなる**（§3.2）。

### 差分が 0 なら `reconcile.drift` を出さない

毎日 WARNING が出続けると、監視の側に**無視する習慣**ができる。
突き合わせが動いていること自体は、`event` キーを持たない素の行が担う
（#39 の `rebuilt N addresses` と同じ扱い）。**§4.7 の表は増やしていない。**

### 判定は開始時点のスナップショットで行う

補完で書いた分を反映すると、**後の source ほど差分が小さく見える**。
1 件ずつ問い合わせず、集合どうしの差を取る——抑制リストは数千件になりうるので、
往復すると日次バッチが往復だけで終わる。

## #40 の本文から逸脱した点

### 応答の射影を `email` だけにした

本文は「4 つの応答を 1 つの DTO へ寄せる」を、`spam_reports` だけ `reason` を
持たないことを理由に却下していた。**実装では `email` 以外を読まない判断にしたので、
DTO は 1 つで済んでいる**——`reason` の文字列は読まず（§4.4 と同じ理由。SendGrid が
文言を変えた日に壊れる）、`reason_code` は `SuppressionSource` が持つ。
`created` も読まない（上記）。**却下の理由そのものが消えた形である。**

### 応答を待つ上限を置いた

本文に無い。既定は無制限で、**SendGrid が応答しない日にスケジューラのスレッドが
戻ってこない**——ページ数に上限を置いたのと同じ理由である。設定項目にはしていない（§5）。

### テスト設定を `support` へ切り出した

対象範囲に無い。コンテキストを起動する 7 クラスが同じ 1 行と同じ説明コメントを
持っていたので、`sendgrid.api.key` を足す前に 1 か所へ寄せた（コミットを分けてある）。

## 実測でわかったこと

- **Boot 4 は `RestClient.Builder` の Bean を auto-configure しない。** 注入しようとすると
  `NoSuchBeanDefinitionException` で起動が止まる（`spring-boot-restclient` が classpath に
  入らない）。**スターターを 1 本足すより、`RestClient.builder()` を自分で呼ぶほうが
  依存が増えない**ので、そうした
- **`timestamptz` はマイクロ秒までしか持たない。** テストが `OffsetDateTime.now()` を
  そのまま入れると、読み戻した値と一致せずに落ちる

## 却下した案

| 案 | 却下理由 |
|---|---|
| 前回実行時刻を記録し、差分だけ取る | 捨てて作り直せない状態が増える。取りこぼしが窓の外に落ちたまま見つからない |
| `blocks` で `sendable` を落とす | 一時的な失敗である。§4.4 の優先度は一度落ちたら戻らない |
| SendGrid 側に無いアドレスの `sendable` を `true` へ戻す | 運用者が手で外した瞬間に、過去のバウンス先へ送り始める |
| 射影側に「突き合わせが書いた行は触らない」分岐を足す | `email_address_state` が再構築できなくなる（§3.2） |
| `/v3/suppression/unsubscribes` を足す | §4.5 の 4 つで取りこぼしは測れる。分岐とテストが増える |
| API キーが無ければ突き合わせを止める | 設定による挙動の切り替え（`CLAUDE.md`「最重要」） |
| WireMock を入れる | `MockRestServiceServer` で足りる |
| 差分 0 でも `reconcile.drift` を出す | 毎日 WARNING が出続け、無視する習慣ができる |

## 確かめ方

`./gradlew build` が **128 件 green**（2026-08-29 実測。**Docker が要る**）。
新規は 24 件（`SuppressionApiClientTest` 11 ／ `SuppressionReconcilerTest` 13）。
**SendGrid アカウントもネットワークも要らない**——4 つのリストは `MockRestServiceServer` が返す。

起動は手元で実走した（同日）。

- `SENDGRID_API_KEY` を渡さないと、`Could not resolve placeholder 'SENDGRID_API_KEY'` で起動が止まる
- 両方を渡すと起動し、日次 03:00 UTC まで外へ出ていかない

org の `writing-baseline.md` §8 の検査も回した（同日）。同一文末の 3 連続は増えず
（`docs/SPEC.md` の 1 箇所は変更前からある）、一文長は SPEC が n=100 ／ 60 字超 1 件、
README が n=96 ／ 60 字超 6 件——**README は変更前の 7 件から減っている。**

## 残るもの

- **#5 はこれで閉じられる。** `reconcile.drift` が最後の 1 つだった
- `docs/HANDOVER.md` の未決事項は、ライセンスヘッダの 1 行だけになった
- 作業順序 10（`SecurityConfig` の oauth チェーン）以降は手つかずである

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
