### PR TITLE
ci: GHCR へ private イメージを push する経路を置く

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  # Dockerfile の base image は digest でピンしてある。github-actions の SHA ピンと
+  # まったく同じ形で、更新経路を作らないと凍結したまま残り、浮動タグより悪くなる。
+  # 更新 PR は digest と末尾のタグのコメントを一緒に書き換える。
+  #
+  # ★ 見るのはリポジトリ直下の Dockerfile だけである。イメージを作るのは
+  #   .github/workflows/image.yml だが、そちらが持つのは action の SHA で、
+  #   base image の版は Dockerfile の 1 行にしか出ない（#56 の判断 3）。
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
     # Testcontainers がイメージを引く時間と、キャッシュが無い初回のビルドで伸びる。
     timeout-minutes: 30
 
+    # ★★ この services ブロックは image.yml（#56）と同じ値を持つ。片方だけ直さないこと。
+    #   重複を workflow_call へ切り出さないのは、間接参照が増えて失敗が静かに起きる
+    #   ためである（判断規約 §4 が YAML アンカーを見送ったのと同じ形）。
+    #
     # ★ この PostgreSQL は jOOQ の codegen 用である。テストはこれを使わない。
     #   テストは Testcontainers が自分で立てる（src/test/kotlin/.../support/PostgresContainer.kt）。
     #   分けてあるのは、テストがこちらのスキーマを汚すと次の jooqCodegen の入力が

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,134 @@
+# develop への push と v* のタグ push で、その commit の SHA で識別できる private イメージを
+# GHCR へ置く。Railway はそれを引く（#48 の決着。この経路の判断は #56）。
+#
+# ★ ci.yml とは別のワークフローである（#56 の判断 1）。
+#   GHCR への push には packages: write が要るが、#45 の受け入れ基準が ci.yml の
+#   permissions を contents: read だけに縛っている。ジョブ単位で上書きする形も採らない
+#   ——あの基準が見ているのは検査ワークフローの権限で、ジョブで足せば同じことになる。
+#
+# ★ paths で絞っていない。ci.yml と同じ理由（判断規約 §1 の表）。recibir は public で、
+#   標準ランナーは org の無料枠を消費しない。絞り損ねてイメージが作られないと、
+#   recibir-ops が指す SHA が黙って古いままになる——「静かに走らない」が最も高くつく。
+#
+# 型と判断規約は propagandist/.github の docs/ci-strategy.md。
+name: イメージ
+
+on:
+  # PR では作らない（#56 の判断 7）。PR にイメージは要らない。
+  push:
+    branches: [develop]
+    tags: ['v*']
+
+# ★ packages: write は GHCR へ push するために要る（判断規約 §4「付けるときは
+#   なぜ要るかをコメントに書く」）。GitHub へ書き戻すのはパッケージだけで、
+#   contents は checkout のための read しか要らない。
+#
+# ★ パッケージを public にする操作をここに置かない。GHCR は public にすると
+#   private に戻せず、既定が private である（#48 の ★）。守るのは「しないこと」だけ。
+permissions:
+  contents: read
+  packages: write
+
+# ★ デプロイ系の型（判断規約 §4）。途中で殺さないのは、殺すとレイヤが中途半端に
+#   上がった状態が残るためである。group に ref を入れていない——目的は同じイメージを
+#   同時に 2 本出さないことで、develop への push と v* のタグ push は待たせてよい
+#   （後者がするのは、既にある SHA タグへ別名を足すことだけ）。
+concurrency:
+  group: image
+  cancel-in-progress: false
+
+jobs:
+  image:
+    name: イメージのビルドと push
+    runs-on: ubuntu-latest
+    # キャッシュが無い初回のビルドと、base image を引く時間で伸びる。
+    timeout-minutes: 30
+
+    # ★★ この services ブロックは ci.yml と同じ値を持つ。片方だけ直さないこと。
+    #   重複を workflow_call へ切り出すと間接参照が増え、失敗が静かに起きる
+    #   （判断規約 §4 が YAML アンカーを見送ったのと同じ形。#56 の判断 4）。
+    #
+    #   ★ この PostgreSQL は jOOQ の codegen 用である。ここではテストを回さないが、
+    #     値を ci.yml と揃えてあるのは build.gradle.kts の flyway / jooq ブロックが
+    #     この接続先を直接持っているためで、別の値を使うと出どころがもう 1 つ増える。
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: recibir
+          POSTGRES_USER: recibir
+          POSTGRES_PASSWORD: recibir
+        ports:
+          - 15432:5432
+        # 立ち上がる前に flywayMigrate を打つと接続拒否で落ちる。compose.yaml と同じ条件。
+        options: >-
+          --health-cmd "pg_isready -U recibir -d recibir"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+
+    steps:
+      # action は SHA でピンする（判断規約 §4）。末尾の版コメントを消さないこと——
+      # Dependabot が SHA と一緒に書き換える対象で、消すとどの版なのか読めなくなる。
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          # build.gradle.kts の toolchain と同じ版。ここが古いと toolchain の解決で落ちる。
+          java-version: '25'
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      # ★ 以下 3 つの順序を変えない。スキーマの入った DB が無いと codegen は空を吐き、
+      #   io.propagandist.jooq.* が解決できずに永続化層が一切コンパイルできない
+      #   （CLAUDE.md「ビルドと実行」）。ci.yml と同じ順序である。
+      - name: スキーマ適用
+        run: ./gradlew flywayMigrate
+
+      - name: jOOQ コード生成
+        run: ./gradlew jooqCodegen
+
+      # ★ build ではなく bootJar である。ktlintCheck もテストも、同じ commit に対して
+      #   ci.yml が回す。ここで回すと二重になり、イメージが出るのが遅くなるだけになる
+      #   ——このワークフローの役割はイメージを作ることで、検査ではない。
+      - name: jar を作る
+        run: ./gradlew bootJar
+
+      # Dockerfile 側でワイルドカードを使わない。build/libs に何が入るかは回したタスクで
+      # 変わる（build なら plain jar も出る）ので、どれを包むかをここで決める。
+      - name: 包む jar を固定名にする
+        run: cp build/libs/recibir-*.jar app.jar
+
+      # ★ docker 系の action を足していない。単段のイメージに buildx の機能
+      #   （キャッシュ・multi-arch・attestation）が 1 つも要らず、足すぶんだけ
+      #   SHA ピンと Dependabot の対象が増える。
+      #
+      # ★ ${{ }} を run の中へ直接展開しない。式の展開はシェルが構文を読むより先に
+      #   起きるので、ref 名に何が入っても文字列のままになる形にしてある。
+      - name: GHCR へログイン
+        env:
+          ACTOR: ${{ github.actor }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$TOKEN" | docker login ghcr.io --username "$ACTOR" --password-stdin
+
+      # ★ latest を作らない（#56 の判断 5）。recibir-ops が指すタグが古ければ、それが
+      #   本体と本番の差である——可変タグを指させると、その差が見えなくなる。
+      #
+      # ★ v* のタグを打った日は、版タグを別名として追加する（同 判断 6）。主は SHA の
+      #   ままで、版タグはそれを指す。揃える／揃えないの分岐を作らずに両方が読める。
+      - name: イメージをビルドして push
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          docker build --tag "$IMAGE:$SHA" .
+          docker push "$IMAGE:$SHA"
+          if [ "$REF_TYPE" = tag ]; then
+            docker tag "$IMAGE:$SHA" "$IMAGE:$REF_NAME"
+            docker push "$IMAGE:$REF_NAME"
+          fi

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -98,9 +98,17 @@ jobs:
         run: ./gradlew bootJar
 
       # Dockerfile 側でワイルドカードを使わない。build/libs に何が入るかは回したタスクで
-      # 変わる（build なら plain jar も出る）ので、どれを包むかをここで決める。
+      # 変わるので、どれを包むかをここで決める。
+      #
+      # ★ -plain.jar を除いている。bootJar しか回さないここでは並ばないが、build を回すと
+      #   jar タスクの出力が並ぶ（2026-08-30 に手元で確認した）。ワイルドカードが 2 つに
+      #   当たった日に、どちらが包まれるかを運に任せない。test -f はそれを同時に見ている
+      #   ——複数なら変数が改行を含み、ファイルとして存在しないので落ちる。
       - name: 包む jar を固定名にする
-        run: cp build/libs/recibir-*.jar app.jar
+        run: |
+          jar=$(find build/libs -name 'recibir-*.jar' ! -name '*-plain.jar')
+          test -f "$jar"
+          cp "$jar" app.jar
 
       # ★ docker 系の action を足していない。単段のイメージに buildx の機能
       #   （キャッシュ・multi-arch・attestation）が 1 つも要らず、足すぶんだけ

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# jar を包むだけの単段である。ビルドはここで回さない（#56 の判断 2）。
+#
+# jOOQ の codegen はスキーマの入った PostgreSQL を要求する（CLAUDE.md「ビルドと実行」）。
+# ビルド段階を Docker に持ち込むと、その DB をどう用意するかという問題がそのまま移る。
+# #48 は「Railway のビルド段階から DB へ到達できるか」を、公式ドキュメントの
+# 「どちらにも記載が無い」と記録している——「無い」ではなく「書かれていない」。
+# 同じ未確認を Docker のビルド段階へ持ち込まないために、jar は
+# .github/workflows/image.yml が service container 付きで作り、ここは包むだけにする。
+#
+# ★ base image は digest でピンしてある（同 判断 9）。末尾のタグのコメントを消さないこと
+#   ——Dependabot が digest と一緒に書き換える対象で、消すとどの版なのか読めなくなる
+#   （.github/dependabot.yml の docker entry。action を SHA でピンするのと同じ形）。
+#
+# ★ JDK ではなく JRE を採る。実行に javac は要らず、イメージに入れるものが減る。
+#   版は build.gradle.kts の toolchain と .github/workflows/ の setup-java に揃えてある。
+FROM eclipse-temurin:25-jre@sha256:f9e65324a37f28209ce7dd0e5149a7aa954520ed936fb87813cf6ded2400a112 # 25-jre
+
+# root で動かさない。ベースイメージが非 root のユーザーを持たないので、ここで作る。
+# 受けるのは外部から届く POST であり（docs/SPEC.md §4.2）、プロセスが権限を持つ理由が無い。
+RUN useradd --system --create-home --shell /usr/sbin/nologin recibir
+USER recibir
+WORKDIR /home/recibir
+
+# 包むのは 1 つの jar だけである。ここで名前を決め打たないのは、version を持つのが
+# build.gradle.kts の側だからで、固定名にするのは image.yml の仕事になる。
+COPY app.jar app.jar
+
+# アプリが listen する既定のポート（Spring Boot の既定）。
+# 実運用でどう当てるかは本体の関知するところではない——接続先と同じく
+# recibir-ops が環境変数で渡す（#1）。
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,17 @@
 # 同じ未確認を Docker のビルド段階へ持ち込まないために、jar は
 # .github/workflows/image.yml が service container 付きで作り、ここは包むだけにする。
 #
-# ★ base image は digest でピンしてある（同 判断 9）。末尾のタグのコメントを消さないこと
-#   ——Dependabot が digest と一緒に書き換える対象で、消すとどの版なのか読めなくなる
+# ★ base image は digest でピンしてある（同 判断 9）。タグを消さないこと——Dependabot が
+#   digest と一緒に書き換える対象で、消すとどの版なのか読めなくなる
 #   （.github/dependabot.yml の docker entry。action を SHA でピンするのと同じ形）。
+#
+#   ★ ci.yml の action と違い、版を行末のコメントで書けない。Dockerfile の # は行頭にしか
+#     置けず、FROM の後ろに付けると parse error になる（2026-08-30 実測）。
+#     digest が優先されるので、タグは版を読ませるためだけに残してある。
 #
 # ★ JDK ではなく JRE を採る。実行に javac は要らず、イメージに入れるものが減る。
 #   版は build.gradle.kts の toolchain と .github/workflows/ の setup-java に揃えてある。
-FROM eclipse-temurin:25-jre@sha256:f9e65324a37f28209ce7dd0e5149a7aa954520ed936fb87813cf6ded2400a112 # 25-jre
+FROM eclipse-temurin:25-jre@sha256:f9e65324a37f28209ce7dd0e5149a7aa954520ed936fb87813cf6ded2400a112
 
 # root で動かさない。ベースイメージが非 root のユーザーを持たないので、ここで作る。
 # 受けるのは外部から届く POST であり（docs/SPEC.md §4.2）、プロセスが権限を持つ理由が無い。


### PR DESCRIPTION
#56 の実装である。決着の本文は #56、その親は #48。

## 何を置いたか

- `Dockerfile`——jar を包むだけの単段。base image は `eclipse-temurin:25-jre` を digest でピン
- `.github/workflows/image.yml`——`develop` への push と `v*` のタグ push で、
  commit SHA のタグを持つ private イメージを GHCR へ置く
- `.github/dependabot.yml`——`docker` の entry
- `.github/workflows/ci.yml`——**コメントを 4 行足しただけ**（下記）

## なぜこの形か

**ビルド段階に DB を持ち込まない。** jOOQ の codegen はスキーマの入った PostgreSQL を
要求するが、#48 は「Railway のビルド段階から DB へ到達できるか」を公式ドキュメントの
「どちらにも記載が無い」と記録している——「無い」ではなく「書かれていない」。
Docker のビルド段階へ同じ未確認を持ち込むと、確かめられないものに依存する経路がもう 1 本
増える。jar は Actions 側が service container 付きで作り、`Dockerfile` は包むだけにした。

**`bootJar` であって `build` ではない。** ktlintCheck もテストも、同じ commit に対して
`ci.yml` が回す。ここで回すと二重になり、イメージが出るのが遅くなるだけになる。

**docker 系の action を足していない。** 単段のイメージに buildx の機能（キャッシュ・
multi-arch・attestation）が 1 つも要らず、足すぶんだけ SHA ピンと Dependabot の対象が
増える。`${{ }}` を `run` の中へ直接展開しないのは、式の展開がシェルの構文解釈より先に
起きるためで、ref 名に何が入っても文字列のままになる形にしてある。

## ★ #56 の本文に無い判断が 2 つある

**1. `ci.yml` を触った。** 入ったのは service container の相互参照コメント 4 行だけで、
`permissions` は 1 文字も変えていない。#56 の対象範囲が `ci.yml` を挙げていないのは
#45 の基準（`contents: read` のまま）を守るためであり、判断 4 は「**両方に**
『片方だけ直さないこと』のコメントを置く」と明示している。

**2. 非 root で動かす。** `Dockerfile` で `useradd` してから `USER` を切り替えている。
受けるのは外部から届く POST であり（`docs/SPEC.md` §4.2）、プロセスが権限を持つ理由が
どこにも無い。

## 確かめたこと

- `docker buildx imagetools inspect eclipse-temurin:25-jre` の Digest を `FROM` に書いた
  （2026-08-30 実測）
- 両ワークフローと `dependabot.yml` が YAML として読めること（同日）

**マージするまで確かめられないものが残る**——GHCR にパッケージが出ること、その
visibility が `private` であること、タグが SHA だけで `latest` を持たないこと。
`image.yml` は PR では走らない（判断 7）。

**だから `Closes` を書いていない。** 受け入れ基準を実測する前に閉じると、検証で落ちた
ときに開け直すことになる（org `work-conventions.md` §4 の ★★）。番号だけで指してある。

## 却下した案

| 案 | 却下理由 |
|---|---|
| `ci.yml` にイメージのジョブを足す | #45 の受け入れ基準が `permissions` を縛っている |
| `bootBuildImage`（Paketo） | JDK 25 の対応が未確認。#48 の理由 2 に逆行する |
| multi-stage でビルドまで行う | codegen に DB が要る（上） |
| `latest` を付けて `recibir-ops` に指させる | ずれが見えなくなる（#48 の理由 3） |
| PR でもイメージを作る | PR にイメージは要らない（判断 7） |
| service container を `workflow_call` へ切り出す | 間接参照が増え、失敗が静かに起きる（判断規約 §4） |
| JRE ではなく JDK の base image | 実行に javac は要らず、入れるものが増えるだけ |
